### PR TITLE
feat!: v8.0.0 — entity-based locations, VTEC parsing, review fixes

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -24,10 +24,8 @@ Derived code by file:
     alert field extraction from NWS API responses (from finity69x2/nws_alerts)
   - coordinator.py: DataUpdateCoordinator structure, _async_update_data pattern
     with async_timeout + UpdateFailed, _get_tracker_gps (from finity69x2/nws_alerts)
-  - config_flow.py: ConfigFlow/OptionsFlow class pattern, tracker entity listing
-    (from finity69x2/nws_alerts)
   - sensor.py: SENSOR_TYPES dict, CoordinatorEntity class structure, state/
-    extra_state_attributes/device_info properties, async_setup_entry pattern
+    device_info properties, async_setup_entry pattern
     (from finity69x2/nws_alerts)
   - manifest.json: structure and field names (from finity69x2/nws_alerts)
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ A Home Assistant custom integration for monitoring weather alerts from the US Na
 
 ## Features
 
-- **Multi-location monitoring** — configure multiple static locations (home, work, school) and tracked devices (phone, car) in a single config entry
-- **Zone and point modes** — each location uses zone queries (broader coverage) or point queries (precise, polygon-based) based on your preference
-- **Automatic zone resolution** — GPS coordinates or Home Assistant zones are automatically resolved to NWS forecast, county, and fire weather zones
+- **Entity-based locations** — static locations are HA zones, tracked locations are device trackers
+- **Automatic zone resolution** — NWS zone IDs are auto-resolved from zone GPS coordinates and editable
+- **Tracker skip optimization** — tracked devices inside a static location's HA zone are skipped (zone query is a superset)
 - **Deduplicated alerts** — same alert observed from multiple locations fires one event, with a `sources` list showing which locations detected it
 - **Combined zone queries** — all zone-mode locations are queried in a single API call, minimizing NWS API usage
 - **Event-driven architecture** — fires `wx_watcher_alert_created`, `wx_watcher_alert_updated`, `wx_watcher_alert_cleared`, and `wx_watcher_alert_stale_data` events for precise automation triggers
@@ -35,18 +35,15 @@ Go to **Settings → Devices & Services → Add Integration** and search for "WX
 
 1. **Name & Settings** — Enter a name (e.g., "WX Watcher"), update interval, and timeout
 2. **Locations Hub** — Add static locations or tracked devices, or finish setup
-3. **Add Static Location** — Choose from:
-   - **Home Assistant zone** — pick a zone from your HA config (auto-resolves GPS and NWS zones)
-   - **Manual GPS** — enter latitude,longitude coordinates
-   - **Manual zone IDs** — enter NWS zone/county codes directly
+3. **Add Static Location** — Select an HA zone. NWS zone IDs are automatically resolved. You can edit them after resolution.
 4. **Add Tracked Device** — Select a device tracker entity and choose zone or point mode
 
 ### Location Types
 
-| Type        | Description                                          |
-| ----------- | ---------------------------------------------------- |
-| **Static**  | Always-monitored fixed location (home, work, school) |
-| **Tracked** | Follows a device_tracker entity (phone, car)         |
+| Type        | Description                                   |
+| ----------- | --------------------------------------------- |
+| **Static**  | Always-monitored HA zone (home, work, school) |
+| **Tracked** | Follows a device_tracker entity (phone, car)  |
 
 ### Query Modes
 
@@ -70,28 +67,28 @@ Events are fired for each unique alert (deduplicated across locations):
 
 Each event carries these fields:
 
-| Field                                           | Description                                                                                    |
-| ----------------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| `Event`                                         | Alert type (e.g., "Excessive Heat Warning")                                                    |
-| `ID`                                            | Stable UUID for the alert                                                                      |
-| `URL`                                           | NWS alert URL                                                                                  |
-| `Headline`                                      | NWS headline text                                                                              |
-| `Type`                                          | Alert type (Alert, Update, Cancel, etc.)                                                       |
-| `NWSCode`                                       | NWS event code                                                                                 |
-| `Status`                                        | Alert status                                                                                   |
-| `Severity`                                      | Severity level                                                                                 |
-| `Certainty`                                     | Certainty level                                                                                |
-| `Urgency`                                       | Urgency level                                                                                  |
-| `Response`                                      | Recommended response                                                                           |
-| `AreasAffected`                                 | Area description                                                                               |
-| `Description`                                   | Full alert description                                                                         |
-| `Instruction`                                   | Recommended actions                                                                            |
-| `Sent`, `Onset`, `Expires`, `Ends`, `Effective` | Timestamps                                                                                     |
-| `VTEC`, `VTECAction`                            | VTEC codes                                                                                     |
-| `References`                                    | Referenced previous alerts                                                                     |
-| `SenderName`                                    | Issuing NWS office                                                                             |
-| `config_entry_id`                               | Config entry that fired the event                                                              |
-| `sources`                                       | List of `{"location": "...", "mode": "..."}` dicts showing which locations observed this alert |
+| Field                                           | Description                                                                                                                                |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `Event`                                         | Alert type (e.g., "Excessive Heat Warning")                                                                                                |
+| `ID`                                            | Stable UUID for the alert                                                                                                                  |
+| `URL`                                           | NWS alert URL                                                                                                                              |
+| `Headline`                                      | NWS headline text                                                                                                                          |
+| `Type`                                          | Alert type (Alert, Update, Cancel, etc.)                                                                                                   |
+| `NWSCode`                                       | NWS event code                                                                                                                             |
+| `Status`                                        | Alert status                                                                                                                               |
+| `Severity`                                      | Severity level                                                                                                                             |
+| `Certainty`                                     | Certainty level                                                                                                                            |
+| `Urgency`                                       | Urgency level                                                                                                                              |
+| `Response`                                      | Recommended response                                                                                                                       |
+| `AreasAffected`                                 | Area description                                                                                                                           |
+| `Description`                                   | Full alert description                                                                                                                     |
+| `Instruction`                                   | Recommended actions                                                                                                                        |
+| `Sent`, `Onset`, `Expires`, `Ends`, `Effective` | Timestamps                                                                                                                                 |
+| `VTEC`, `VTECAction`                            | VTEC codes                                                                                                                                 |
+| `References`                                    | Referenced previous alerts                                                                                                                 |
+| `SenderName`                                    | Issuing NWS office                                                                                                                         |
+| `config_entry_id`                               | Config entry that fired the event                                                                                                          |
+| `sources`                                       | List of source dicts. Static: `{"ha_zone": "zone.home", "mode": "zone"}`. Tracked: `{"tracker": "device_tracker.phone", "mode": "point"}`. |
 
 ### Automation Example
 
@@ -103,6 +100,11 @@ automation:
     trigger:
       - trigger: event
         event_type: wx_watcher_alert_created
+    condition:
+      - condition: template
+        value_template: >-
+          {{ 'zone.home' in
+            (trigger.event.data.sources | map(attribute='ha_zone') | list) }}
     action:
       - action: notify.mobile_phone
         data:
@@ -112,6 +114,36 @@ automation:
             url: "{{ trigger.event.data.URL }}"
 ```
 
+## Blueprints
+
+### WX Watcher → Ticker
+
+An automation blueprint that routes WX Watcher alert notifications based on
+static locations (HA zones) and tracked devices. Import multiple times for
+different users or notification targets.
+
+The integration automatically skips NWS queries for tracked devices that are
+currently inside a configured static location's HA zone, since the zone query
+is a superset. No duplicate queries or redundant notifications.
+
+**Import:** Paste this URL in **Settings → Automations & scenes → Blueprints → Import Blueprint**:
+
+```
+https://github.com/nalabelle/wx_watcher/blob/main/blueprints/automation/wx_watcher_ticker.yaml
+```
+
+To update, re-import the blueprint from the same URL.
+
+**Inputs:**
+
+| Input             | Description                                                |
+| ----------------- | ---------------------------------------------------------- |
+| Static Locations  | One or more HA zones to monitor                            |
+| Tracked Devices   | One or more device tracker entities to follow              |
+| Warning Category  | Category for Warning alerts (default: `Weather Warning`)   |
+| Watch Category    | Category for Watch alerts (default: `Weather Watch`)       |
+| Advisory Category | Category for Advisory alerts (default: `Weather Advisory`) |
+
 ## Sensors
 
 | Entity                           | State                            | Attributes                                                                           |
@@ -119,15 +151,14 @@ automation:
 | `sensor.wx_watcher_alerts`       | Number of active alerts          | `Alerts` (full list with sources), `locations` (configured locations), `attribution` |
 | `sensor.wx_watcher_last_updated` | Last successful update timestamp | `attribution`                                                                        |
 
-## Breaking Changes from nws_alerts v6
-
-WX Watcher is a complete redesign. If you were using the `nws_alerts` integration:
+## Breaking Changes from v7
 
 - **You must delete your old config entries and reconfigure** — the data model is incompatible
-- The domain changed from `nws_alerts to `wx_watcher` — all entity IDs change
-- Event names changed from `nws_alerts_alert_*` to `wx_watcher_alert_*`
-- Event data no longer includes `config_name`; it now includes `sources`
-- The old per-entry dedup automation condition (`config_name != 'NWS Alerts Phone'`) is no longer needed
+- Location names removed — locations are now defined by HA zone entities (static) or device tracker entities (tracked)
+- Event source data uses `ha_zone` and `tracker` keys instead of `location`
+- Manual GPS and manual NWS zone ID source options removed — all static locations start from an HA zone
+- NWS zone IDs are auto-resolved but editable
+- Tracked devices inside a static location's HA zone are automatically skipped (zone query is a superset)
 
 ## Attribution
 

--- a/README.md
+++ b/README.md
@@ -67,28 +67,29 @@ Events are fired for each unique alert (deduplicated across locations):
 
 Each event carries these fields:
 
-| Field                                           | Description                                                                                                                                |
-| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| `Event`                                         | Alert type (e.g., "Excessive Heat Warning")                                                                                                |
-| `ID`                                            | Stable UUID for the alert                                                                                                                  |
-| `URL`                                           | NWS alert URL                                                                                                                              |
-| `Headline`                                      | NWS headline text                                                                                                                          |
-| `Type`                                          | Alert type (Alert, Update, Cancel, etc.)                                                                                                   |
-| `NWSCode`                                       | NWS event code                                                                                                                             |
-| `Status`                                        | Alert status                                                                                                                               |
-| `Severity`                                      | Severity level                                                                                                                             |
-| `Certainty`                                     | Certainty level                                                                                                                            |
-| `Urgency`                                       | Urgency level                                                                                                                              |
-| `Response`                                      | Recommended response                                                                                                                       |
-| `AreasAffected`                                 | Area description                                                                                                                           |
-| `Description`                                   | Full alert description                                                                                                                     |
-| `Instruction`                                   | Recommended actions                                                                                                                        |
-| `Sent`, `Onset`, `Expires`, `Ends`, `Effective` | Timestamps                                                                                                                                 |
-| `VTEC`, `VTECAction`                            | VTEC codes                                                                                                                                 |
-| `References`                                    | Referenced previous alerts                                                                                                                 |
-| `SenderName`                                    | Issuing NWS office                                                                                                                         |
-| `config_entry_id`                               | Config entry that fired the event                                                                                                          |
-| `sources`                                       | List of source dicts. Static: `{"ha_zone": "zone.home", "mode": "zone"}`. Tracked: `{"tracker": "device_tracker.phone", "mode": "point"}`. |
+| Field                                           | Description                                                                                                                                                     |
+| ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Event`                                         | Alert type (e.g., "Excessive Heat Warning")                                                                                                                     |
+| `ID`                                            | Stable UUID for the alert                                                                                                                                       |
+| `URL`                                           | NWS alert URL                                                                                                                                                   |
+| `Headline`                                      | NWS headline text                                                                                                                                               |
+| `Type`                                          | Alert type (Alert, Update, Cancel, etc.)                                                                                                                        |
+| `NWSCode`                                       | NWS event code                                                                                                                                                  |
+| `Status`                                        | Alert status                                                                                                                                                    |
+| `Severity`                                      | Severity level                                                                                                                                                  |
+| `Certainty`                                     | Certainty level                                                                                                                                                 |
+| `Urgency`                                       | Urgency level                                                                                                                                                   |
+| `Response`                                      | Recommended response                                                                                                                                            |
+| `AreasAffected`                                 | Area description                                                                                                                                                |
+| `Description`                                   | Full alert description                                                                                                                                          |
+| `Instruction`                                   | Recommended actions                                                                                                                                             |
+| `Sent`, `Onset`, `Expires`, `Ends`, `Effective` | Timestamps                                                                                                                                                      |
+| `VTEC`, `VTECAction`                            | VTEC codes                                                                                                                                                      |
+| `Significance`                                  | VTEC significance code (`W` = Warning, `A` = Watch, `Y` = Advisory, `S` = Statement, `O` = Outlook, `N` = Synopsis, `F` = Forecast). Empty for non-VTEC alerts. |
+| `References`                                    | Referenced previous alerts                                                                                                                                      |
+| `SenderName`                                    | Issuing NWS office                                                                                                                                              |
+| `config_entry_id`                               | Config entry that fired the event                                                                                                                               |
+| `sources`                                       | List of source dicts. Static: `{"ha_zone": "zone.home", "mode": "zone"}`. Tracked: `{"tracker": "device_tracker.phone", "mode": "point"}`.                      |
 
 ### Automation Example
 

--- a/blueprints/automation/wx_watcher_ticker.yaml
+++ b/blueprints/automation/wx_watcher_ticker.yaml
@@ -1,0 +1,165 @@
+blueprint:
+  name: WX Watcher → Ticker
+  description: >-
+    Routes WX Watcher alert notifications based on static locations (HA zones)
+    and tracked devices.
+
+    Configure which zones and devices to monitor, and where to send
+    notifications. Import multiple times for different users or notification
+    targets — e.g., one instance for your phone, another for a family member.
+
+    The integration automatically skips NWS queries for tracked devices that
+    are currently inside a configured static location's HA zone, since the
+    zone query is a superset. No duplicate queries or redundant notifications.
+
+    - **Warning** alerts (🔴) use the warning category
+    - **Watch** alerts (🟡) use the watch category
+    - **Advisory** and other alerts (🔵) use the advisory category
+    - Cleared alerts send a clear message to dismiss the notification
+
+    Notifications are deduplicated by alert ID using tags.
+
+    Designed for [Ticker](https://github.com/analytix-energy-solutions/ticker). Category
+    names must match your Ticker category names or IDs.
+  domain: automation
+  source_url: https://github.com/nalabelle/wx_watcher/blob/main/blueprints/automation/wx_watcher_ticker.yaml
+  author: nalabelle
+  homeassistant:
+    min_version: 2026.2.0
+  input:
+    conditions_section:
+      name: Conditions
+      icon: mdi:filter
+      input:
+        static_locations:
+          name: Static Locations
+          description: >-
+            One or more HA zones to monitor. Alerts fire when any of these
+            zones appear in the alert's sources, or when a tracked device's
+            location appears in the sources.
+          selector:
+            entity:
+              filter:
+                domain: zone
+              multiple: true
+        tracked_devices:
+          name: Tracked Devices
+          description: >-
+            One or more device trackers to follow. Alerts also fire when any
+            of these devices' locations appear in the alert's sources.
+            Devices inside a static location's HA zone are automatically
+            skipped by the integration.
+          selector:
+            entity:
+              filter:
+                domain: device_tracker
+              multiple: true
+    notification_section:
+      name: Notification
+      icon: mdi:bell
+      input:
+        warning_category:
+          name: Warning Category
+          default: Weather Warning
+          selector:
+            text:
+        watch_category:
+          name: Watch Category
+          default: Weather Watch
+          selector:
+            text:
+        advisory_category:
+          name: Advisory Category
+          default: Weather Advisory
+          selector:
+            text:
+
+variables:
+  static_locations: !input static_locations
+  tracked_devices: !input tracked_devices
+  warning_category: !input warning_category
+  watch_category: !input watch_category
+  advisory_category: !input advisory_category
+
+mode: queued
+max: 10
+
+triggers:
+  - trigger: event
+    event_type: wx_watcher_alert_created
+  - trigger: event
+    event_type: wx_watcher_alert_updated
+  - trigger: event
+    event_type: wx_watcher_alert_cleared
+
+conditions:
+  - condition: template
+    value_template: >-
+      {{ trigger.event.data.sources | map(attribute='ha_zone') | list
+            | select('in', static_locations) | list | count > 0
+          or trigger.event.data.sources | map(attribute='tracker') | list
+            | select('in', tracked_devices) | list | count > 0 }}
+
+actions:
+  - if:
+      - condition: template
+        value_template: >-
+          {{ trigger.event.event_type == 'wx_watcher_alert_cleared' }}
+    then:
+      - action: ticker.notify
+        data:
+          message: clear_notification
+          data:
+            tag: wx_{{ trigger.event.data.ID }}
+    else:
+      - choose:
+          - conditions:
+              - condition: template
+                value_template: >-
+                  {{ 'Warning' in trigger.event.data.Event }}
+            sequence:
+              - action: ticker.notify
+                data:
+                  category: "{{ warning_category }}"
+                  title: >-
+                    🔴 {{ 'Updated' if trigger.event.event_type ==
+                      'wx_watcher_alert_updated' else 'New' }}:
+                      {{ trigger.event.data.Event }}
+                  message: >-
+                    {{ trigger.event.data.Headline }}{% if
+                      trigger.event.data.Instruction %}
+                      {{ trigger.event.data.Instruction }}{% endif %}
+                  data:
+                    tag: wx_{{ trigger.event.data.ID }}
+                    url: "{{ trigger.event.data.URL }}"
+          - conditions:
+              - condition: template
+                value_template: >-
+                  {{ 'Watch' in trigger.event.data.Event }}
+            sequence:
+              - action: ticker.notify
+                data:
+                  category: "{{ watch_category }}"
+                  title: >-
+                    🟡 {{ 'Updated' if trigger.event.event_type ==
+                      'wx_watcher_alert_updated' else 'New' }}:
+                      {{ trigger.event.data.Event }}
+                  message: >-
+                    {{ trigger.event.data.Headline }}{% if
+                      trigger.event.data.Instruction %}
+                      {{ trigger.event.data.Instruction }}{% endif %}
+                  data:
+                    tag: wx_{{ trigger.event.data.ID }}
+                    url: "{{ trigger.event.data.URL }}"
+        default:
+          - action: ticker.notify
+            data:
+              category: "{{ advisory_category }}"
+              title: "🔵 {{ trigger.event.data.Event }}"
+              message: >-
+                {{ trigger.event.data.Headline }}{% if
+                  trigger.event.data.Instruction %}
+                  {{ trigger.event.data.Instruction }}{% endif %}
+              data:
+                tag: wx_{{ trigger.event.data.ID }}
+                url: "{{ trigger.event.data.URL }}"

--- a/blueprints/automation/wx_watcher_ticker.yaml
+++ b/blueprints/automation/wx_watcher_ticker.yaml
@@ -21,6 +21,10 @@ blueprint:
 
     Designed for [Ticker](https://github.com/analytix-energy-solutions/ticker). Category
     names must match your Ticker category names or IDs.
+
+    The automation is queued with a max of 10 concurrent runs. If your area
+    frequently has more than 10 simultaneous alerts, raise `max` after
+    importing the blueprint.
   domain: automation
   source_url: https://github.com/nalabelle/wx_watcher/blob/main/blueprints/automation/wx_watcher_ticker.yaml
   author: nalabelle

--- a/blueprints/automation/wx_watcher_ticker.yaml
+++ b/blueprints/automation/wx_watcher_ticker.yaml
@@ -12,8 +12,8 @@ blueprint:
     are currently inside a configured static location's HA zone, since the
     zone query is a superset. No duplicate queries or redundant notifications.
 
-    - **Warning** alerts (🔴) use the warning category
-    - **Watch** alerts (🟡) use the watch category
+    - **Warning** alerts (🔴, VTEC significance `W`) use the warning category
+    - **Watch** alerts (🟡, VTEC significance `A`) use the watch category
     - **Advisory** and other alerts (🔵) use the advisory category
     - Cleared alerts send a clear message to dismiss the notification
 
@@ -116,7 +116,7 @@ actions:
           - conditions:
               - condition: template
                 value_template: >-
-                  {{ 'Warning' in trigger.event.data.Event }}
+                  {{ trigger.event.data.Significance == 'W' }}
             sequence:
               - action: ticker.notify
                 data:
@@ -135,7 +135,7 @@ actions:
           - conditions:
               - condition: template
                 value_template: >-
-                  {{ 'Watch' in trigger.event.data.Event }}
+                  {{ trigger.event.data.Significance == 'A' }}
             sequence:
               - action: ticker.notify
                 data:

--- a/custom_components/wx_watcher/api.py
+++ b/custom_components/wx_watcher/api.py
@@ -15,6 +15,7 @@ import uuid
 import aiohttp
 
 from .const import API_ENDPOINT
+from .vtec import VTECParseError, parse_vtec
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -173,12 +174,27 @@ def parse_alert(raw_alert: dict[str, Any]) -> dict[str, Any] | None:
         "FormattedHeadline": props.get("headline", ""),
         "VTEC": props.get("parameters", {}).get("VTEC", []),
         "VTECAction": None,
+        "Significance": "",
         "References": props.get("references", []),
         "_ugc": ugc,
     }
 
     vtec_list = parsed["VTEC"]
-    parsed["VTECAction"] = vtec_list[0].split(".")[1] if vtec_list else None
+    if vtec_list:
+        try:
+            tokens = parse_vtec(vtec_list[0])
+        except VTECParseError:
+            _LOGGER.warning(
+                "Failed to parse VTEC for alert %s: %s",
+                alert_id,
+                vtec_list[0],
+                exc_info=True,
+            )
+        else:
+            parsed["VTECAction"] = tokens.action
+            parsed["Significance"] = tokens.significance
+    else:
+        parsed["VTECAction"] = None
 
     return parsed
 

--- a/custom_components/wx_watcher/config_flow.py
+++ b/custom_components/wx_watcher/config_flow.py
@@ -1,12 +1,5 @@
 """Adds config flow for WX Watcher."""
 
-# Derived in part from nws_alerts by finity69x2
-# (https://github.com/finity69x2/nws_alerts).
-# ConfigFlow/OptionsFlow class pattern and tracker entity listing originate
-# from the upstream config flow. See NOTICE for details.
-# As upstream-derived code is rewritten or removed, this comment should
-# be updated or removed accordingly.
-
 from __future__ import annotations
 
 import logging
@@ -15,7 +8,6 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.components.device_tracker.const import DOMAIN as TRACKER_DOMAIN
 from homeassistant.config_entries import ConfigEntry, ConfigFlowResult
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant, callback
@@ -33,8 +25,8 @@ from .api import resolve_zones
 from .const import (
     CONF_INTERVAL,
     CONF_LOCATION_GPS,
+    CONF_LOCATION_HA_ZONE,
     CONF_LOCATION_MODE,
-    CONF_LOCATION_NAME,
     CONF_LOCATION_TRACKER,
     CONF_LOCATION_TYPE,
     CONF_LOCATION_ZONE,
@@ -54,40 +46,190 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-
-def _get_tracker_entities(hass: HomeAssistant) -> list[str]:
-    """Get list of device tracker entity IDs."""
-    data = ["(none)"]
-    entities = hass.states.async_entity_ids(TRACKER_DOMAIN)
-    data.extend(entities)
-    return data
+MODE_OPTIONS = [
+    SelectOptionDict(value=LOCATION_MODE_ZONE, label="Zone mode (broader coverage)"),
+    SelectOptionDict(value=LOCATION_MODE_POINT, label="Point mode (precise location)"),
+]
 
 
-def _get_ha_zone_entities(hass: HomeAssistant) -> list[SelectOptionDict]:
-    """Get list of HA zone entity IDs as select options."""
-    options = [SelectOptionDict(value="(none)", label="None")]
-    for entity_id in sorted(hass.states.async_entity_ids("zone")):
+def _hub_actions(done_label: str) -> list[SelectOptionDict]:
+    """Return action options for the locations menu."""
+    return [
+        SelectOptionDict(value="add_static", label="Add a static location"),
+        SelectOptionDict(value="add_tracked", label="Add a tracked device"),
+        SelectOptionDict(value="edit_location", label="Edit a location"),
+        SelectOptionDict(value="remove_location", label="Remove a location"),
+        SelectOptionDict(value="done", label=done_label),
+    ]
+
+
+def _location_display(hass: HomeAssistant, loc: dict[str, Any]) -> str:
+    """Return a human-readable label for a location."""
+    entity_id = loc.get(CONF_LOCATION_HA_ZONE) or loc.get(CONF_LOCATION_TRACKER, "")
+    state = hass.states.get(entity_id)
+    name = state.name if state else entity_id
+    return f"{name} ({loc[CONF_LOCATION_TYPE]}, {loc[CONF_LOCATION_MODE]})"
+
+
+def _location_list_str(hass: HomeAssistant, locations: list[dict[str, Any]]) -> str:
+    """Return a comma-separated summary of all locations."""
+    if not locations:
+        return "None"
+    return ", ".join(_location_display(hass, loc) for loc in locations)
+
+
+def _location_select_options(
+    hass: HomeAssistant, locations: list[dict[str, Any]]
+) -> list[SelectOptionDict]:
+    """Return select options for the location picker."""
+    options = []
+    for i, loc in enumerate(locations):
+        entity_id = loc.get(CONF_LOCATION_HA_ZONE) or loc.get(CONF_LOCATION_TRACKER, "")
         state = hass.states.get(entity_id)
-        label = entity_id
-        if state:
-            label = f"{state.name} ({entity_id})"
-        options.append(SelectOptionDict(value=entity_id, label=label))
+        name = state.name if state else entity_id
+        loc_type = "static" if loc[CONF_LOCATION_TYPE] == LOCATION_TYPE_STATIC else "tracked"
+        label = f"{name} ({loc_type}, {loc[CONF_LOCATION_MODE]})"
+        options.append(SelectOptionDict(value=str(i), label=label))
     return options
 
 
+def _dedupe_zone_str(zone_str: str) -> str:
+    """Deduplicate and sort comma-separated zone IDs."""
+    zones = sorted({z.strip() for z in zone_str.split(",") if z.strip()})
+    return ",".join(zones)
+
+
+def _static_schema(
+    ha_zone_default: str | None = None,
+    mode_default: str = LOCATION_MODE_ZONE,
+    zone_default: str = "",
+) -> vol.Schema:
+    """Return a voluptuous schema for the static-location form."""
+    return vol.Schema(
+        {
+            vol.Required(CONF_LOCATION_HA_ZONE, default=ha_zone_default): EntitySelector(
+                EntitySelectorConfig(domain="zone")
+            ),
+            vol.Required(CONF_LOCATION_MODE, default=mode_default): SelectSelector(
+                SelectSelectorConfig(options=MODE_OPTIONS)
+            ),
+            vol.Optional(CONF_LOCATION_ZONE, default=zone_default): str,
+        }
+    )
+
+
+def _tracked_schema(
+    tracker_default: str | None = None,
+    mode_default: str = LOCATION_MODE_ZONE,
+) -> vol.Schema:
+    """Return a voluptuous schema for the tracked-device form."""
+    return vol.Schema(
+        {
+            vol.Required(CONF_LOCATION_TRACKER, default=tracker_default): EntitySelector(
+                EntitySelectorConfig(domain="device_tracker")
+            ),
+            vol.Required(CONF_LOCATION_MODE, default=mode_default): SelectSelector(
+                SelectSelectorConfig(options=MODE_OPTIONS)
+            ),
+        }
+    )
+
+
+async def _validate_static(
+    hass: HomeAssistant, user_input: dict[str, Any]
+) -> tuple[dict[str, Any] | None, dict[str, str], dict[str, Any]]:
+    """Validate a static location submission.
+
+    Returns (location_dict | None, errors, form_data).
+    """
+    errors: dict[str, str] = {}
+    ha_zone = user_input.get(CONF_LOCATION_HA_ZONE, "")
+    mode = user_input[CONF_LOCATION_MODE]
+    zone_str = user_input.get(CONF_LOCATION_ZONE, "")
+    gps = ""
+
+    state = hass.states.get(ha_zone)
+    if not state:
+        errors["base"] = "no_zone_selected"
+    elif "latitude" not in state.attributes or "longitude" not in state.attributes:
+        errors["base"] = "zone_no_gps"
+    else:
+        gps = f"{state.attributes['latitude']},{state.attributes['longitude']}"
+
+    if not errors and mode == LOCATION_MODE_ZONE and not zone_str:
+        instance_id = await async_get_instance_id(hass)
+        user_agent = USER_AGENT.format(instance_id)
+        session = async_get_clientsession(hass)
+        lat_str, lon_str = gps.split(",")
+        zones = await resolve_zones(session, user_agent, float(lat_str), float(lon_str))
+        if zones:
+            zone_str = ",".join(zones)
+        else:
+            errors["base"] = "zone_resolve_failed"
+
+    if not errors:
+        location = {
+            CONF_LOCATION_TYPE: LOCATION_TYPE_STATIC,
+            CONF_LOCATION_MODE: mode,
+            CONF_LOCATION_GPS: gps,
+            CONF_LOCATION_ZONE: _dedupe_zone_str(zone_str),
+            CONF_LOCATION_HA_ZONE: ha_zone,
+        }
+        return location, errors, {}
+
+    return (
+        None,
+        errors,
+        {
+            CONF_LOCATION_HA_ZONE: ha_zone,
+            CONF_LOCATION_MODE: mode,
+            CONF_LOCATION_ZONE: zone_str,
+        },
+    )
+
+
+def _validate_tracked(
+    hass: HomeAssistant, user_input: dict[str, Any]
+) -> tuple[dict[str, Any] | None, dict[str, str]]:
+    """Validate a tracked-device submission.
+
+    Returns (location_dict | None, errors).
+    """
+    errors: dict[str, str] = {}
+    tracker = user_input.get(CONF_LOCATION_TRACKER, "")
+    mode = user_input[CONF_LOCATION_MODE]
+
+    state = hass.states.get(tracker)
+    if not state:
+        errors["base"] = "tracker_not_found"
+
+    if not errors:
+        location = {
+            CONF_LOCATION_TYPE: LOCATION_TYPE_TRACKED,
+            CONF_LOCATION_MODE: mode,
+            CONF_LOCATION_GPS: "",
+            CONF_LOCATION_ZONE: "",
+            CONF_LOCATION_TRACKER: tracker,
+        }
+        return location, errors
+
+    return None, errors
+
+
 class WXWatcherFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
-    """Config flow for WX Watcher."""
+    """Handle a config flow for WX Watcher."""
 
     VERSION = CONFIG_VERSION
 
     def __init__(self) -> None:
-        """Initialize."""
+        """Initialize the config flow handler."""
         self._data: dict[str, Any] = {}
         self._locations: list[dict[str, Any]] = []
         self._errors: dict[str, str] = {}
+        self._edit_index: int = -1
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
-        """Handle the initial step — entry name and settings."""
+        """Handle the initial user step."""
         if user_input is not None:
             self._data[CONF_NAME] = user_input[CONF_NAME]
             self._data[CONF_INTERVAL] = user_input.get(CONF_INTERVAL, DEFAULT_INTERVAL)
@@ -109,396 +251,407 @@ class WXWatcherFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_locations(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Hub page showing current locations and add/done buttons."""
+        """Handle the locations menu step."""
         if user_input is not None:
             action = user_input.get("action")
             if action == "add_static":
                 return await self.async_step_add_static()
             if action == "add_tracked":
                 return await self.async_step_add_tracked()
+            if action == "edit_location":
+                return await self.async_step_edit_location()
+            if action == "remove_location":
+                return await self.async_step_remove_location()
             if action == "done":
                 return self._create_entry()
-
-        location_list = (
-            ", ".join(
-                f"{loc[CONF_LOCATION_NAME]} ({loc[CONF_LOCATION_TYPE]}, {loc[CONF_LOCATION_MODE]})"
-                for loc in self._locations
-            )
-            if self._locations
-            else "None"
-        )
 
         return self.async_show_form(
             step_id="locations",
             data_schema=vol.Schema(
                 {
                     vol.Required("action"): SelectSelector(
-                        SelectSelectorConfig(
-                            options=[
-                                SelectOptionDict(value="add_static", label="Add a static location"),
-                                SelectOptionDict(value="add_tracked", label="Add a tracked device"),
-                                SelectOptionDict(value="done", label="Done — finish setup"),
-                            ],
-                        )
+                        SelectSelectorConfig(options=_hub_actions("Done — finish setup"))
                     ),
                 }
             ),
-            description_placeholders={"location_list": location_list},
+            description_placeholders={
+                "location_list": _location_list_str(self.hass, self._locations),
+            },
         )
 
     async def async_step_add_static(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle adding a static location."""
-        errors: dict[str, str] = {}
-
         if user_input is not None:
-            name = user_input[CONF_LOCATION_NAME]
-            mode = user_input[CONF_LOCATION_MODE]
-            source = user_input.get("source", "manual_gps")
-            zone_str = ""
-            gps = ""
-
-            if source == "ha_zone":
-                ha_zone = user_input.get("ha_zone", "(none)")
-                if ha_zone == "(none)":
-                    errors["ha_zone"] = "no_zone_selected"
-                else:
-                    state = self.hass.states.get(ha_zone)
-                    if state and "latitude" in state.attributes and "longitude" in state.attributes:
-                        gps = f"{state.attributes['latitude']},{state.attributes['longitude']}"
-                    else:
-                        errors["ha_zone"] = "zone_no_gps"
-
-            if source == "manual_gps":
-                gps = user_input.get(CONF_LOCATION_GPS, "").replace(" ", "")
-
-            if not errors:
-                if mode == LOCATION_MODE_ZONE and gps:
-                    instance_id = await async_get_instance_id(self.hass)
-                    user_agent = USER_AGENT.format(instance_id)
-                    session = async_get_clientsession(self.hass)
-                    lat_str, lon_str = gps.split(",")
-                    zones = await resolve_zones(session, user_agent, float(lat_str), float(lon_str))
-                    if zones:
-                        zone_str = ",".join(zones)
-                    else:
-                        errors["base"] = "zone_resolve_failed"
-
-                if mode == LOCATION_MODE_ZONE and not gps and not zone_str:
-                    if source == "manual_zone":
-                        zone_str = user_input.get(CONF_LOCATION_ZONE, "").replace(" ", "")
-                    if not zone_str:
-                        errors["base"] = "no_zone_or_gps"
-
-            if not errors:
-                if source == "manual_zone":
-                    zone_str = user_input.get(CONF_LOCATION_ZONE, "").replace(" ", "")
-
-                location: dict[str, Any] = {
-                    CONF_LOCATION_NAME: name,
-                    CONF_LOCATION_TYPE: LOCATION_TYPE_STATIC,
-                    CONF_LOCATION_MODE: mode,
-                    CONF_LOCATION_GPS: gps,
-                    CONF_LOCATION_ZONE: zone_str,
-                }
-                if source == "ha_zone":
-                    location["ha_zone"] = user_input.get("ha_zone", "")
+            location, errors, form_data = await _validate_static(self.hass, user_input)
+            if location:
                 self._locations.append(location)
                 return await self.async_step_locations()
-
-        source_options = [
-            SelectOptionDict(value="ha_zone", label="Home Assistant zone"),
-            SelectOptionDict(value="manual_gps", label="Manual GPS coordinates"),
-            SelectOptionDict(value="manual_zone", label="Manual NWS zone IDs"),
-        ]
-        mode_options = [
-            SelectOptionDict(value=LOCATION_MODE_ZONE, label="Zone mode (broader coverage)"),
-            SelectOptionDict(value=LOCATION_MODE_POINT, label="Point mode (precise location)"),
-        ]
-
-        schema_dict: dict[vol.Marker, Any] = {
-            vol.Required(CONF_LOCATION_NAME): str,
-            vol.Required("source", default="ha_zone"): SelectSelector(
-                SelectSelectorConfig(options=source_options)
-            ),
-            vol.Required(CONF_LOCATION_MODE, default=LOCATION_MODE_ZONE): SelectSelector(
-                SelectSelectorConfig(options=mode_options)
-            ),
-        }
-        schema_dict[vol.Optional(CONF_LOCATION_GPS, default="")] = str
-        schema_dict[vol.Optional(CONF_LOCATION_ZONE, default="")] = str
-        schema_dict[vol.Optional("ha_zone", default="(none)")] = EntitySelector(
-            EntitySelectorConfig(domain="zone")
-        )
+            return self.async_show_form(
+                step_id="add_static",
+                data_schema=_static_schema(
+                    ha_zone_default=form_data.get(CONF_LOCATION_HA_ZONE),
+                    mode_default=form_data.get(CONF_LOCATION_MODE, LOCATION_MODE_ZONE),
+                    zone_default=form_data.get(CONF_LOCATION_ZONE, ""),
+                ),
+                errors=errors,
+            )
 
         return self.async_show_form(
             step_id="add_static",
-            data_schema=vol.Schema(schema_dict),
-            errors=errors,
+            data_schema=_static_schema(),
         )
 
     async def async_step_add_tracked(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Handle adding a tracked device location."""
-        errors: dict[str, str] = {}
-
+        """Handle adding a tracked device."""
         if user_input is not None:
-            name = user_input[CONF_LOCATION_NAME]
-            tracker = user_input.get(CONF_LOCATION_TRACKER, "(none)")
-            mode = user_input[CONF_LOCATION_MODE]
-
-            if tracker == "(none)":
-                errors["tracker"] = "no_tracker_selected"
-            else:
-                state = self.hass.states.get(tracker)
-                if state is None:
-                    errors["tracker"] = "tracker_not_found"
-
-            if not errors:
-                location: dict[str, Any] = {
-                    CONF_LOCATION_NAME: name,
-                    CONF_LOCATION_TYPE: LOCATION_TYPE_TRACKED,
-                    CONF_LOCATION_MODE: mode,
-                    CONF_LOCATION_GPS: "",
-                    CONF_LOCATION_ZONE: "",
-                    CONF_LOCATION_TRACKER: tracker,
-                }
+            location, errors = _validate_tracked(self.hass, user_input)
+            if location:
                 self._locations.append(location)
                 return await self.async_step_locations()
-
-        tracker_entities = _get_tracker_entities(self.hass)
-        mode_options = [
-            SelectOptionDict(value=LOCATION_MODE_ZONE, label="Zone mode (broader coverage)"),
-            SelectOptionDict(value=LOCATION_MODE_POINT, label="Point mode (precise location)"),
-        ]
-
-        schema = vol.Schema(
-            {
-                vol.Required(CONF_LOCATION_NAME): str,
-                vol.Required(CONF_LOCATION_TRACKER, default="(none)"): vol.In(tracker_entities),
-                vol.Required(CONF_LOCATION_MODE, default=LOCATION_MODE_ZONE): SelectSelector(
-                    SelectSelectorConfig(options=mode_options)
-                ),
-            }
-        )
+            return self.async_show_form(
+                step_id="add_tracked",
+                data_schema=_tracked_schema(),
+                errors=errors,
+            )
 
         return self.async_show_form(
             step_id="add_tracked",
-            data_schema=schema,
-            errors=errors,
+            data_schema=_tracked_schema(),
+        )
+
+    async def async_step_edit_location(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle selecting a location to edit."""
+        if not self._locations:
+            return await self.async_step_locations()
+
+        if user_input is not None and "location_index" in user_input:
+            idx = int(user_input["location_index"])
+            if idx < 0 or idx >= len(self._locations):
+                return await self.async_step_locations()
+            self._edit_index = idx
+            loc = self._locations[idx]
+            if loc[CONF_LOCATION_TYPE] == LOCATION_TYPE_STATIC:
+                return self.async_show_form(
+                    step_id="edit_static",
+                    data_schema=_static_schema(
+                        ha_zone_default=loc.get(CONF_LOCATION_HA_ZONE),
+                        mode_default=loc[CONF_LOCATION_MODE],
+                        zone_default=loc.get(CONF_LOCATION_ZONE, ""),
+                    ),
+                )
+            return self.async_show_form(
+                step_id="edit_tracked",
+                data_schema=_tracked_schema(
+                    tracker_default=loc.get(CONF_LOCATION_TRACKER),
+                    mode_default=loc[CONF_LOCATION_MODE],
+                ),
+            )
+
+        return self.async_show_form(
+            step_id="edit_location",
+            data_schema=vol.Schema(
+                {
+                    vol.Required("location_index"): SelectSelector(
+                        SelectSelectorConfig(
+                            options=_location_select_options(self.hass, self._locations)
+                        )
+                    ),
+                }
+            ),
+        )
+
+    async def async_step_edit_static(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle editing a static location."""
+        idx = self._edit_index
+        if idx < 0 or idx >= len(self._locations):
+            return await self.async_step_locations()
+
+        if user_input is not None:
+            location, errors, form_data = await _validate_static(self.hass, user_input)
+            if location:
+                self._locations[idx] = location
+                return await self.async_step_locations()
+            return self.async_show_form(
+                step_id="edit_static",
+                data_schema=_static_schema(
+                    ha_zone_default=form_data.get(CONF_LOCATION_HA_ZONE),
+                    mode_default=form_data.get(CONF_LOCATION_MODE, LOCATION_MODE_ZONE),
+                    zone_default=form_data.get(CONF_LOCATION_ZONE, ""),
+                ),
+                errors=errors,
+            )
+
+        return await self.async_step_locations()
+
+    async def async_step_edit_tracked(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle editing a tracked device."""
+        idx = self._edit_index
+        if idx < 0 or idx >= len(self._locations):
+            return await self.async_step_locations()
+
+        if user_input is not None:
+            location, errors = _validate_tracked(self.hass, user_input)
+            if location:
+                self._locations[idx] = location
+                return await self.async_step_locations()
+            return self.async_show_form(
+                step_id="edit_tracked",
+                data_schema=_tracked_schema(
+                    tracker_default=self._locations[idx].get(CONF_LOCATION_TRACKER),
+                    mode_default=self._locations[idx][CONF_LOCATION_MODE],
+                ),
+                errors=errors,
+            )
+
+        return await self.async_step_locations()
+
+    async def async_step_remove_location(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle removing a location."""
+        if not self._locations:
+            return await self.async_step_locations()
+
+        if user_input is not None and "location_index" in user_input:
+            idx = int(user_input["location_index"])
+            if 0 <= idx < len(self._locations):
+                self._locations.pop(idx)
+            return await self.async_step_locations()
+
+        return self.async_show_form(
+            step_id="remove_location",
+            data_schema=vol.Schema(
+                {
+                    vol.Required("location_index"): SelectSelector(
+                        SelectSelectorConfig(
+                            options=_location_select_options(self.hass, self._locations)
+                        )
+                    ),
+                }
+            ),
         )
 
     def _create_entry(self) -> ConfigFlowResult:
-        """Create the config entry."""
+        """Create the config entry from collected data."""
         self._data[CONF_LOCATIONS] = self._locations
         return self.async_create_entry(title=self._data[CONF_NAME], data=self._data)
 
     @staticmethod
     @callback
     def async_get_options_flow(config_entry: ConfigEntry) -> WXWatcherOptionsFlow:
-        """Display options flow."""
+        """Return the options flow handler."""
         return WXWatcherOptionsFlow(config_entry)
 
 
 class WXWatcherOptionsFlow(config_entries.OptionsFlow):
-    """Options flow for WX Watcher."""
+    """Handle options flow for WX Watcher."""
 
     def __init__(self, config_entry: ConfigEntry) -> None:
-        """Initialize."""
+        """Initialize the options flow handler."""
         self._config = config_entry
         self._data = dict(config_entry.data)
         self._locations: list[dict[str, Any]] = list(config_entry.data.get(CONF_LOCATIONS, []))
         self._errors: dict[str, str] = {}
+        self._edit_index: int = -1
 
     async def async_step_init(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
-        """Manage options — locations hub."""
+        """Handle the options flow main menu."""
         if user_input is not None:
             action = user_input.get("action")
             if action == "add_static":
                 return await self.async_step_add_static()
             if action == "add_tracked":
                 return await self.async_step_add_tracked()
+            if action == "edit_location":
+                return await self.async_step_edit_location()
+            if action == "remove_location":
+                return await self.async_step_remove_location()
             if action == "done":
                 self._data[CONF_LOCATIONS] = self._locations
                 return self.async_create_entry(title="", data=self._data)
-
-        location_list = (
-            ", ".join(
-                f"{loc[CONF_LOCATION_NAME]} ({loc[CONF_LOCATION_TYPE]}, {loc[CONF_LOCATION_MODE]})"
-                for loc in self._locations
-            )
-            if self._locations
-            else "None"
-        )
 
         return self.async_show_form(
             step_id="init",
             data_schema=vol.Schema(
                 {
                     vol.Required("action"): SelectSelector(
-                        SelectSelectorConfig(
-                            options=[
-                                SelectOptionDict(value="add_static", label="Add a static location"),
-                                SelectOptionDict(value="add_tracked", label="Add a tracked device"),
-                                SelectOptionDict(value="done", label="Done — save changes"),
-                            ],
-                        )
+                        SelectSelectorConfig(options=_hub_actions("Done — save changes"))
                     ),
                 }
             ),
-            description_placeholders={"location_list": location_list},
+            description_placeholders={
+                "location_list": _location_list_str(self.hass, self._locations),
+            },
         )
 
     async def async_step_add_static(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Handle adding a static location in options."""
-        return await self._handle_add_static(user_input)
+        """Handle adding a static location."""
+        if user_input is not None:
+            location, errors, form_data = await _validate_static(self.hass, user_input)
+            if location:
+                self._locations.append(location)
+                return await self.async_step_init()
+            return self.async_show_form(
+                step_id="add_static",
+                data_schema=_static_schema(
+                    ha_zone_default=form_data.get(CONF_LOCATION_HA_ZONE),
+                    mode_default=form_data.get(CONF_LOCATION_MODE, LOCATION_MODE_ZONE),
+                    zone_default=form_data.get(CONF_LOCATION_ZONE, ""),
+                ),
+                errors=errors,
+            )
+
+        return self.async_show_form(
+            step_id="add_static",
+            data_schema=_static_schema(),
+        )
 
     async def async_step_add_tracked(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Handle adding a tracked device in options."""
-        return await self._handle_add_tracked(user_input)
-
-    async def _handle_add_static(self, user_input: dict[str, Any] | None) -> ConfigFlowResult:
-        """Shared static location logic between setup and options."""
-        errors: dict[str, str] = {}
-
+        """Handle adding a tracked device."""
         if user_input is not None:
-            name = user_input[CONF_LOCATION_NAME]
-            mode = user_input[CONF_LOCATION_MODE]
-            source = user_input.get("source", "manual_gps")
-            zone_str = ""
-            gps = ""
-
-            if source == "ha_zone":
-                ha_zone = user_input.get("ha_zone", "(none)")
-                if ha_zone == "(none)":
-                    errors["ha_zone"] = "no_zone_selected"
-                else:
-                    state = self.hass.states.get(ha_zone)
-                    if state and "latitude" in state.attributes and "longitude" in state.attributes:
-                        gps = f"{state.attributes['latitude']},{state.attributes['longitude']}"
-                    else:
-                        errors["ha_zone"] = "zone_no_gps"
-
-            if source == "manual_gps":
-                gps = user_input.get(CONF_LOCATION_GPS, "").replace(" ", "")
-
-            if not errors:
-                if mode == LOCATION_MODE_ZONE and gps:
-                    instance_id = await async_get_instance_id(self.hass)
-                    user_agent = USER_AGENT.format(instance_id)
-                    session = async_get_clientsession(self.hass)
-                    lat_str, lon_str = gps.split(",")
-                    zones = await resolve_zones(session, user_agent, float(lat_str), float(lon_str))
-                    if zones:
-                        zone_str = ",".join(zones)
-                    else:
-                        errors["base"] = "zone_resolve_failed"
-
-                if mode == LOCATION_MODE_ZONE and not gps and not zone_str:
-                    if source == "manual_zone":
-                        zone_str = user_input.get(CONF_LOCATION_ZONE, "").replace(" ", "")
-                    if not zone_str:
-                        errors["base"] = "no_zone_or_gps"
-
-            if not errors:
-                if source == "manual_zone":
-                    zone_str = user_input.get(CONF_LOCATION_ZONE, "").replace(" ", "")
-
-                location: dict[str, Any] = {
-                    CONF_LOCATION_NAME: name,
-                    CONF_LOCATION_TYPE: LOCATION_TYPE_STATIC,
-                    CONF_LOCATION_MODE: mode,
-                    CONF_LOCATION_GPS: gps,
-                    CONF_LOCATION_ZONE: zone_str,
-                }
-                if source == "ha_zone":
-                    location["ha_zone"] = user_input.get("ha_zone", "")
+            location, errors = _validate_tracked(self.hass, user_input)
+            if location:
                 self._locations.append(location)
                 return await self.async_step_init()
-
-        source_options = [
-            SelectOptionDict(value="ha_zone", label="Home Assistant zone"),
-            SelectOptionDict(value="manual_gps", label="Manual GPS coordinates"),
-            SelectOptionDict(value="manual_zone", label="Manual NWS zone IDs"),
-        ]
-        mode_options = [
-            SelectOptionDict(value=LOCATION_MODE_ZONE, label="Zone mode (broader coverage)"),
-            SelectOptionDict(value=LOCATION_MODE_POINT, label="Point mode (precise location)"),
-        ]
-
-        schema_dict: dict[vol.Marker, Any] = {
-            vol.Required(CONF_LOCATION_NAME): str,
-            vol.Required("source", default="ha_zone"): SelectSelector(
-                SelectSelectorConfig(options=source_options)
-            ),
-            vol.Required(CONF_LOCATION_MODE, default=LOCATION_MODE_ZONE): SelectSelector(
-                SelectSelectorConfig(options=mode_options)
-            ),
-            vol.Optional(CONF_LOCATION_GPS, default=""): str,
-            vol.Optional(CONF_LOCATION_ZONE, default=""): str,
-            vol.Optional("ha_zone", default="(none)"): EntitySelector(
-                EntitySelectorConfig(domain="zone")
-            ),
-        }
-
-        return self.async_show_form(
-            step_id="add_static",
-            data_schema=vol.Schema(schema_dict),
-            errors=errors,
-        )
-
-    async def _handle_add_tracked(self, user_input: dict[str, Any] | None) -> ConfigFlowResult:
-        """Shared tracked location logic between setup and options."""
-        errors: dict[str, str] = {}
-
-        if user_input is not None:
-            name = user_input[CONF_LOCATION_NAME]
-            tracker = user_input.get(CONF_LOCATION_TRACKER, "(none)")
-            mode = user_input[CONF_LOCATION_MODE]
-
-            if tracker == "(none)":
-                errors["tracker"] = "no_tracker_selected"
-            else:
-                state = self.hass.states.get(tracker)
-                if state is None:
-                    errors["tracker"] = "tracker_not_found"
-
-            if not errors:
-                location: dict[str, Any] = {
-                    CONF_LOCATION_NAME: name,
-                    CONF_LOCATION_TYPE: LOCATION_TYPE_TRACKED,
-                    CONF_LOCATION_MODE: mode,
-                    CONF_LOCATION_GPS: "",
-                    CONF_LOCATION_ZONE: "",
-                    CONF_LOCATION_TRACKER: tracker,
-                }
-                self._locations.append(location)
-                return await self.async_step_init()
-
-        tracker_entities = _get_tracker_entities(self.hass)
-        mode_options = [
-            SelectOptionDict(value=LOCATION_MODE_ZONE, label="Zone mode (broader coverage)"),
-            SelectOptionDict(value=LOCATION_MODE_POINT, label="Point mode (precise location)"),
-        ]
-
-        schema = vol.Schema(
-            {
-                vol.Required(CONF_LOCATION_NAME): str,
-                vol.Required(CONF_LOCATION_TRACKER, default="(none)"): vol.In(tracker_entities),
-                vol.Required(CONF_LOCATION_MODE, default=LOCATION_MODE_ZONE): SelectSelector(
-                    SelectSelectorConfig(options=mode_options)
-                ),
-            }
-        )
+            return self.async_show_form(
+                step_id="add_tracked",
+                data_schema=_tracked_schema(),
+                errors=errors,
+            )
 
         return self.async_show_form(
             step_id="add_tracked",
-            data_schema=schema,
-            errors=errors,
+            data_schema=_tracked_schema(),
+        )
+
+    async def async_step_edit_location(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle selecting a location to edit."""
+        if not self._locations:
+            return await self.async_step_init()
+
+        if user_input is not None and "location_index" in user_input:
+            idx = int(user_input["location_index"])
+            if idx < 0 or idx >= len(self._locations):
+                return await self.async_step_init()
+            self._edit_index = idx
+            loc = self._locations[idx]
+            if loc[CONF_LOCATION_TYPE] == LOCATION_TYPE_STATIC:
+                return self.async_show_form(
+                    step_id="edit_static",
+                    data_schema=_static_schema(
+                        ha_zone_default=loc.get(CONF_LOCATION_HA_ZONE),
+                        mode_default=loc[CONF_LOCATION_MODE],
+                        zone_default=loc.get(CONF_LOCATION_ZONE, ""),
+                    ),
+                )
+            return self.async_show_form(
+                step_id="edit_tracked",
+                data_schema=_tracked_schema(
+                    tracker_default=loc.get(CONF_LOCATION_TRACKER),
+                    mode_default=loc[CONF_LOCATION_MODE],
+                ),
+            )
+
+        return self.async_show_form(
+            step_id="edit_location",
+            data_schema=vol.Schema(
+                {
+                    vol.Required("location_index"): SelectSelector(
+                        SelectSelectorConfig(
+                            options=_location_select_options(self.hass, self._locations)
+                        )
+                    ),
+                }
+            ),
+        )
+
+    async def async_step_edit_static(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle editing a static location."""
+        idx = self._edit_index
+        if idx < 0 or idx >= len(self._locations):
+            return await self.async_step_init()
+
+        if user_input is not None:
+            location, errors, form_data = await _validate_static(self.hass, user_input)
+            if location:
+                self._locations[idx] = location
+                return await self.async_step_init()
+            return self.async_show_form(
+                step_id="edit_static",
+                data_schema=_static_schema(
+                    ha_zone_default=form_data.get(CONF_LOCATION_HA_ZONE),
+                    mode_default=form_data.get(CONF_LOCATION_MODE, LOCATION_MODE_ZONE),
+                    zone_default=form_data.get(CONF_LOCATION_ZONE, ""),
+                ),
+                errors=errors,
+            )
+
+        return await self.async_step_init()
+
+    async def async_step_edit_tracked(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle editing a tracked device."""
+        idx = self._edit_index
+        if idx < 0 or idx >= len(self._locations):
+            return await self.async_step_init()
+
+        if user_input is not None:
+            location, errors = _validate_tracked(self.hass, user_input)
+            if location:
+                self._locations[idx] = location
+                return await self.async_step_init()
+            return self.async_show_form(
+                step_id="edit_tracked",
+                data_schema=_tracked_schema(
+                    tracker_default=self._locations[idx].get(CONF_LOCATION_TRACKER),
+                    mode_default=self._locations[idx][CONF_LOCATION_MODE],
+                ),
+                errors=errors,
+            )
+
+        return await self.async_step_init()
+
+    async def async_step_remove_location(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle removing a location."""
+        if not self._locations:
+            return await self.async_step_init()
+
+        if user_input is not None and "location_index" in user_input:
+            idx = int(user_input["location_index"])
+            if 0 <= idx < len(self._locations):
+                self._locations.pop(idx)
+            return await self.async_step_init()
+
+        return self.async_show_form(
+            step_id="remove_location",
+            data_schema=vol.Schema(
+                {
+                    vol.Required("location_index"): SelectSelector(
+                        SelectSelectorConfig(
+                            options=_location_select_options(self.hass, self._locations)
+                        )
+                    ),
+                }
+            ),
         )

--- a/custom_components/wx_watcher/config_flow.py
+++ b/custom_components/wx_watcher/config_flow.py
@@ -148,13 +148,17 @@ async def _validate_static(
     zone_str = user_input.get(CONF_LOCATION_ZONE, "")
     gps = ""
 
-    state = hass.states.get(ha_zone)
-    if not state:
+    if not ha_zone:
         errors["base"] = "no_zone_selected"
-    elif "latitude" not in state.attributes or "longitude" not in state.attributes:
-        errors["base"] = "zone_no_gps"
-    else:
-        gps = f"{state.attributes['latitude']},{state.attributes['longitude']}"
+
+    if not errors:
+        state = hass.states.get(ha_zone)
+        if not state:
+            errors["base"] = "no_zone_selected"
+        elif "latitude" not in state.attributes or "longitude" not in state.attributes:
+            errors["base"] = "zone_no_gps"
+        else:
+            gps = f"{state.attributes['latitude']},{state.attributes['longitude']}"
 
     if not errors and mode == LOCATION_MODE_ZONE and not zone_str:
         instance_id = await async_get_instance_id(hass)

--- a/custom_components/wx_watcher/const.py
+++ b/custom_components/wx_watcher/const.py
@@ -10,50 +10,42 @@
 
 from homeassistant.const import Platform
 
-# API
 API_ENDPOINT = "https://api.weather.gov"
 USER_AGENT = "wx_watcher homeassistant {}"
 
-# Config
 CONF_TIMEOUT = "timeout"
 CONF_INTERVAL = "interval"
 
-# Location config
 CONF_LOCATIONS = "locations"
-CONF_LOCATION_NAME = "name"
 CONF_LOCATION_TYPE = "type"
 CONF_LOCATION_MODE = "mode"
 CONF_LOCATION_GPS = "gps"
 CONF_LOCATION_ZONE = "zone"
 CONF_LOCATION_TRACKER = "tracker"
+CONF_LOCATION_HA_ZONE = "ha_zone"
 
-# Location types
 LOCATION_TYPE_STATIC = "static"
 LOCATION_TYPE_TRACKED = "tracked"
 
-# Location modes
 LOCATION_MODE_ZONE = "zone"
 LOCATION_MODE_POINT = "point"
 
-# Defaults
 DEFAULT_ICON = "mdi:alert"
 DEFAULT_NAME = "WX Watcher"
 DEFAULT_INTERVAL = 1
 DEFAULT_TIMEOUT = 120
 
-# Event attributes
 EVENT_ATTR_CONFIG_ENTRY_ID = "config_entry_id"
 EVENT_ATTR_SOURCES = "sources"
 
-# Misc
-VERSION = "7.0.1"
+VERSION = "8.0.0"
 ISSUE_URL = "https://github.com/nalabelle/wx_watcher"
 DOMAIN = "wx_watcher"
 PLATFORM = "sensor"
 ATTRIBUTION = "Data provided by Weather.gov"
 COORDINATOR = "coordinator"
 PLATFORMS = [Platform.SENSOR]
-CONFIG_VERSION = 3
+CONFIG_VERSION = 4
 
 EVENT_ALERT_CREATED = f"{DOMAIN}_alert_created"
 EVENT_ALERT_UPDATED = f"{DOMAIN}_alert_updated"

--- a/custom_components/wx_watcher/coordinator.py
+++ b/custom_components/wx_watcher/coordinator.py
@@ -24,8 +24,8 @@ from .api import fetch_point_alerts, fetch_zone_alerts, parse_alert, resolve_zon
 from .const import (
     CONF_INTERVAL,
     CONF_LOCATION_GPS,
+    CONF_LOCATION_HA_ZONE,
     CONF_LOCATION_MODE,
-    CONF_LOCATION_NAME,
     CONF_LOCATION_TRACKER,
     CONF_LOCATION_TYPE,
     CONF_LOCATION_ZONE,
@@ -33,6 +33,7 @@ from .const import (
     CONF_TIMEOUT,
     LOCATION_MODE_POINT,
     LOCATION_MODE_ZONE,
+    LOCATION_TYPE_STATIC,
     LOCATION_TYPE_TRACKED,
 )
 from .events import async_fire_alert_events, async_fire_stale_data_event
@@ -41,9 +42,24 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def _parse_gps(gps_str: str) -> tuple[float, float]:
-    """Parse a 'lat,lon' string into (lat, lon) floats."""
+    """Parse a ``lat,lon`` string into a float tuple."""
     parts = gps_str.replace(" ", "").split(",")
     return float(parts[0]), float(parts[1])
+
+
+def _entity_id(loc: dict[str, Any]) -> str:
+    """Return the primary entity ID for a location dict."""
+    return loc.get(CONF_LOCATION_HA_ZONE) or loc.get(CONF_LOCATION_TRACKER, "")
+
+
+def _build_source(loc: dict[str, Any]) -> dict[str, str]:
+    """Build a source descriptor from a location configuration."""
+    source: dict[str, str] = {"mode": loc[CONF_LOCATION_MODE]}
+    if loc.get(CONF_LOCATION_HA_ZONE):
+        source["ha_zone"] = loc[CONF_LOCATION_HA_ZONE]
+    if loc.get(CONF_LOCATION_TRACKER):
+        source["tracker"] = loc[CONF_LOCATION_TRACKER]
+    return source
 
 
 class AlertsDataUpdateCoordinator(DataUpdateCoordinator):
@@ -85,7 +101,6 @@ class AlertsDataUpdateCoordinator(DataUpdateCoordinator):
         return self._entry_id
 
     async def _async_update_data(self) -> dict[str, Any]:
-        """Fetch data from all locations and merge."""
         async with async_timeout(self._timeout):
             try:
                 data = await self._fetch_all_locations()
@@ -100,23 +115,64 @@ class AlertsDataUpdateCoordinator(DataUpdateCoordinator):
             return data
 
     async def _fetch_all_locations(self) -> dict[str, Any]:
-        """Fetch alerts from all locations, merge by ID, return deduplicated data."""
+        """Fetch alerts for all configured locations."""
+        static_zone_slugs = {
+            loc[CONF_LOCATION_HA_ZONE].replace("zone.", "")
+            for loc in self._locations
+            if loc[CONF_LOCATION_TYPE] == LOCATION_TYPE_STATIC and loc.get(CONF_LOCATION_HA_ZONE)
+        }
+
+        location_zones, point_tasks = await self._build_fetch_tasks(static_zone_slugs)
+
+        all_zone_ids: set[str] = set()
+        for loc_zones in location_zones.values():
+            all_zone_ids.update(loc_zones)
+
         zone_alerts_raw: list[dict[str, Any]] = []
-        point_tasks: list[tuple[dict, Any]] = []
+        if all_zone_ids:
+            zone_alerts_raw = await fetch_zone_alerts(
+                self._session, self._user_agent, sorted(all_zone_ids)
+            )
+
+        point_results = await self._fetch_point_alerts(point_tasks)
+
+        merged = self._merge_zone_alerts(zone_alerts_raw, location_zones)
+        self._merge_point_alerts(point_results, merged)
+
+        alerts = sorted(merged.values(), key=lambda x: x["ID"])
+        return {
+            "state": len(alerts),
+            "alerts": alerts,
+            "last_updated": datetime.now(tz=UTC).isoformat(),
+        }
+
+    async def _build_fetch_tasks(
+        self, static_zone_slugs: set[str]
+    ) -> tuple[dict[str, set[str]], list[tuple[dict, tuple[float, float]]]]:
+        """Build zone-lookup and point-fetch tasks from configured locations."""
         location_zones: dict[str, set[str]] = {}
+        point_tasks: list[tuple[dict, tuple[float, float]]] = []
 
         for loc in self._locations:
-            loc_name = loc[CONF_LOCATION_NAME]
-            loc_mode = loc[CONF_LOCATION_MODE]
             loc_type = loc[CONF_LOCATION_TYPE]
+            loc_mode = loc[CONF_LOCATION_MODE]
 
             if loc_type == LOCATION_TYPE_TRACKED:
-                gps = await self._get_tracker_gps(loc[CONF_LOCATION_TRACKER])
+                tracker_entity = loc[CONF_LOCATION_TRACKER]
+                tracker_state = self.hass.states.get(tracker_entity)
+                if tracker_state and tracker_state.state in static_zone_slugs:
+                    _LOGGER.debug(
+                        "Tracker %s is inside static zone %s, skipping",
+                        tracker_entity,
+                        tracker_state.state,
+                    )
+                    continue
+
+                gps = await self._get_tracker_gps(tracker_entity)
                 if gps is None:
                     _LOGGER.debug(
-                        "Tracker %s unavailable, skipping location %s",
-                        loc.get(CONF_LOCATION_TRACKER),
-                        loc_name,
+                        "Tracker %s unavailable, skipping",
+                        tracker_entity,
                     )
                     continue
                 loc[CONF_LOCATION_GPS] = gps
@@ -128,97 +184,97 @@ class AlertsDataUpdateCoordinator(DataUpdateCoordinator):
                     zones = await resolve_zones(self._session, self._user_agent, lat, lon)
                     if zones is None:
                         _LOGGER.warning(
-                            "Could not resolve zones for location %s, skipping", loc_name
+                            "Could not resolve zones for location %s, skipping",
+                            self._display_name(_entity_id(loc)),
                         )
                         continue
                     zone_str = ",".join(zones)
                     loc[CONF_LOCATION_ZONE] = zone_str
 
                 loc_zones = {z.strip() for z in zone_str.split(",") if z.strip()}
-                location_zones[loc_name] = loc_zones
+                location_zones[_entity_id(loc)] = loc_zones
 
             elif loc_mode == LOCATION_MODE_POINT:
                 lat, lon = _parse_gps(loc[CONF_LOCATION_GPS])
                 point_tasks.append((loc, (lat, lon)))
 
-        all_zone_ids: set[str] = set()
-        for loc_zones in location_zones.values():
-            all_zone_ids.update(loc_zones)
+        return location_zones, point_tasks
 
-        if all_zone_ids:
-            zone_alerts_raw = await fetch_zone_alerts(
-                self._session, self._user_agent, sorted(all_zone_ids)
-            )
+    async def _fetch_point_alerts(
+        self, point_tasks: list[tuple[dict, tuple[float, float]]]
+    ) -> dict[str, list[dict[str, Any]]]:
+        """Fetch point alerts for all point-mode locations concurrently."""
+        if not point_tasks:
+            return {}
 
-        point_results: dict[str, list[dict[str, Any]]] = {}
-        if point_tasks:
-            coros = [
-                fetch_point_alerts(self._session, self._user_agent, coords[0], coords[1])
-                for _, coords in point_tasks
-            ]
-            raw_results = await asyncio.gather(*coros, return_exceptions=True)
-            for i, result in enumerate(raw_results):
-                loc_name = point_tasks[i][0][CONF_LOCATION_NAME]
-                if isinstance(result, Exception):
-                    _LOGGER.warning("Failed to fetch point alerts for %s: %s", loc_name, result)
-                else:
-                    point_results[loc_name] = cast(list[dict[str, Any]], result)
+        coros = [
+            fetch_point_alerts(self._session, self._user_agent, coords[0], coords[1])
+            for _, coords in point_tasks
+        ]
+        raw_results = await asyncio.gather(*coros, return_exceptions=True)
+        results: dict[str, list[dict[str, Any]]] = {}
+        for i, result in enumerate(raw_results):
+            loc = point_tasks[i][0]
+            eid = _entity_id(loc)
+            if isinstance(result, Exception):
+                _LOGGER.warning(
+                    "Failed to fetch point alerts for %s: %s",
+                    self._display_name(eid),
+                    result,
+                )
+            else:
+                results[eid] = cast(list[dict[str, Any]], result)
+        return results
 
+    def _merge_zone_alerts(
+        self,
+        zone_alerts_raw: list[dict[str, Any]],
+        location_zones: dict[str, set[str]],
+    ) -> dict[str, dict[str, Any]]:
+        """Merge raw zone alerts and assign source locations."""
         merged: dict[str, dict[str, Any]] = {}
+        for raw_alert in zone_alerts_raw:
+            parsed = parse_alert(raw_alert)
+            if parsed is None:
+                continue
+            alert_id = parsed["ID"]
+            ugc: set[str] = set(parsed.pop("_ugc", []))
+            sources = []
+            for entity_id, loc_zones in location_zones.items():
+                if ugc & loc_zones:
+                    loc = next(loc for loc in self._locations if _entity_id(loc) == entity_id)
+                    sources.append(_build_source(loc))
 
-        if all_zone_ids:
-            for raw_alert in zone_alerts_raw:
-                parsed = parse_alert(raw_alert)
-                if parsed is None:
-                    continue
-                alert_id = parsed["ID"]
-                ugc: set[str] = set(parsed.pop("_ugc", []))
-                sources = []
-                for loc_name, loc_zones in location_zones.items():
-                    if ugc & loc_zones:
-                        loc = next(
-                            loc for loc in self._locations if loc[CONF_LOCATION_NAME] == loc_name
-                        )
-                        sources.append(
-                            {
-                                "location": loc_name,
-                                "mode": loc[CONF_LOCATION_MODE],
-                            }
-                        )
-                if not sources and location_zones:
-                    matching = [ln for ln, lz in location_zones.items() if ugc & lz]
-                    sources = [{"location": n, "mode": "zone"} for n in matching]
+            if alert_id in merged:
+                merged[alert_id]["sources"].extend(sources)
+            else:
+                parsed["sources"] = sources
+                merged[alert_id] = parsed
+        return merged
 
-                if alert_id in merged:
-                    merged[alert_id]["sources"].extend(sources)
-                else:
-                    parsed["sources"] = sources
-                    merged[alert_id] = parsed
-
-        for loc_name, raw_alerts in point_results.items():
-            loc = next(loc for loc in self._locations if loc[CONF_LOCATION_NAME] == loc_name)
+    def _merge_point_alerts(
+        self,
+        point_results: dict[str, list[dict[str, Any]]],
+        merged: dict[str, dict[str, Any]],
+    ) -> None:
+        """Merge point-alert results into *merged* in place."""
+        for entity_id, raw_alerts in point_results.items():
+            loc = next(loc for loc in self._locations if _entity_id(loc) == entity_id)
             for raw_alert in raw_alerts:
                 parsed = parse_alert(raw_alert)
                 if parsed is None:
                     continue
                 alert_id = parsed["ID"]
                 parsed.pop("_ugc", None)
-                source = {"location": loc_name, "mode": loc[CONF_LOCATION_MODE]}
+                source = _build_source(loc)
                 if alert_id in merged:
                     merged[alert_id]["sources"].append(source)
                 else:
                     parsed["sources"] = [source]
                     merged[alert_id] = parsed
 
-        alerts = sorted(merged.values(), key=lambda x: x["ID"])
-        return {
-            "state": len(alerts),
-            "alerts": alerts,
-            "last_updated": datetime.now(tz=UTC).isoformat(),
-        }
-
     async def _get_tracker_gps(self, tracker_entity_id: str) -> str | None:
-        """Return 'lat,lon' string from a device tracker, or None if unavailable."""
+        """Return ``lat,lon`` string for a tracker entity, or None."""
         entity = self.hass.states.get(tracker_entity_id)
         if entity is None:
             _LOGGER.warning("Tracker entity %s not found", tracker_entity_id)
@@ -228,3 +284,8 @@ class AlertsDataUpdateCoordinator(DataUpdateCoordinator):
             return f"{attrs['latitude']},{attrs['longitude']}"
         _LOGGER.warning("Tracker %s missing latitude/longitude attributes", tracker_entity_id)
         return None
+
+    def _display_name(self, entity_id: str) -> str:
+        """Return the friendly name for an entity ID."""
+        state = self.hass.states.get(entity_id)
+        return state.name if state else entity_id

--- a/custom_components/wx_watcher/coordinator.py
+++ b/custom_components/wx_watcher/coordinator.py
@@ -41,10 +41,26 @@ from .events import async_fire_alert_events, async_fire_stale_data_event
 _LOGGER = logging.getLogger(__name__)
 
 
-def _parse_gps(gps_str: str) -> tuple[float, float]:
+def _parse_gps_str(gps_str: str) -> tuple[float, float]:
     """Parse a ``lat,lon`` string into a float tuple."""
     parts = gps_str.replace(" ", "").split(",")
     return float(parts[0]), float(parts[1])
+
+
+def _safe_parse_gps(loc: dict[str, Any]) -> tuple[float, float] | None:
+    """Parse GPS coordinates from a location dict, with validation and error handling.
+
+    Returns (lat, lon) on success, or None with a logged warning on failure.
+    """
+    gps = loc.get(CONF_LOCATION_GPS, "")
+    if not gps:
+        _LOGGER.warning("No GPS coordinates for %s, skipping", _entity_id(loc))
+        return None
+    try:
+        return _parse_gps_str(gps)
+    except (ValueError, IndexError) as err:
+        _LOGGER.warning("Invalid GPS format for %s: %s", _entity_id(loc), err)
+        return None
 
 
 def _entity_id(loc: dict[str, Any]) -> str:
@@ -101,6 +117,7 @@ class AlertsDataUpdateCoordinator(DataUpdateCoordinator):
         return self._entry_id
 
     async def _async_update_data(self) -> dict[str, Any]:
+        """Fetch data from all locations and merge."""
         async with async_timeout(self._timeout):
             try:
                 data = await self._fetch_all_locations()
@@ -180,7 +197,10 @@ class AlertsDataUpdateCoordinator(DataUpdateCoordinator):
             if loc_mode == LOCATION_MODE_ZONE:
                 zone_str = loc.get(CONF_LOCATION_ZONE, "")
                 if loc_type == LOCATION_TYPE_TRACKED or not zone_str:
-                    lat, lon = _parse_gps(loc[CONF_LOCATION_GPS])
+                    coords = _safe_parse_gps(loc)
+                    if coords is None:
+                        continue
+                    lat, lon = coords
                     zones = await resolve_zones(self._session, self._user_agent, lat, lon)
                     if zones is None:
                         _LOGGER.warning(
@@ -195,7 +215,10 @@ class AlertsDataUpdateCoordinator(DataUpdateCoordinator):
                 location_zones[_entity_id(loc)] = loc_zones
 
             elif loc_mode == LOCATION_MODE_POINT:
-                lat, lon = _parse_gps(loc[CONF_LOCATION_GPS])
+                coords = _safe_parse_gps(loc)
+                if coords is None:
+                    continue
+                lat, lon = coords
                 point_tasks.append((loc, (lat, lon)))
 
         return location_zones, point_tasks

--- a/custom_components/wx_watcher/coordinator.py
+++ b/custom_components/wx_watcher/coordinator.py
@@ -133,13 +133,13 @@ class AlertsDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def _fetch_all_locations(self) -> dict[str, Any]:
         """Fetch alerts for all configured locations."""
-        static_zone_slugs = {
-            loc[CONF_LOCATION_HA_ZONE].replace("zone.", "")
+        static_zone_entity_ids = {
+            loc[CONF_LOCATION_HA_ZONE]
             for loc in self._locations
             if loc[CONF_LOCATION_TYPE] == LOCATION_TYPE_STATIC and loc.get(CONF_LOCATION_HA_ZONE)
         }
 
-        location_zones, point_tasks = await self._build_fetch_tasks(static_zone_slugs)
+        location_zones, point_tasks = await self._build_fetch_tasks(static_zone_entity_ids)
 
         all_zone_ids: set[str] = set()
         for loc_zones in location_zones.values():
@@ -164,7 +164,7 @@ class AlertsDataUpdateCoordinator(DataUpdateCoordinator):
         }
 
     async def _build_fetch_tasks(
-        self, static_zone_slugs: set[str]
+        self, static_zone_entity_ids: set[str]
     ) -> tuple[dict[str, set[str]], list[tuple[dict, tuple[float, float]]]]:
         """Build zone-lookup and point-fetch tasks from configured locations."""
         location_zones: dict[str, set[str]] = {}
@@ -177,7 +177,7 @@ class AlertsDataUpdateCoordinator(DataUpdateCoordinator):
             if loc_type == LOCATION_TYPE_TRACKED:
                 tracker_entity = loc[CONF_LOCATION_TRACKER]
                 tracker_state = self.hass.states.get(tracker_entity)
-                if tracker_state and tracker_state.state in static_zone_slugs:
+                if tracker_state and tracker_state.state in static_zone_entity_ids:
                     _LOGGER.debug(
                         "Tracker %s is inside static zone %s, skipping",
                         tracker_entity,

--- a/custom_components/wx_watcher/sensor.py
+++ b/custom_components/wx_watcher/sensor.py
@@ -3,7 +3,8 @@
 # Derived in part from nws_alerts by finity69x2
 # (https://github.com/finity69x2/nws_alerts).
 # Sensor class structure, SENSOR_TYPES pattern, and setup pattern originate
-# from the upstream sensor module. See NOTICE for details.
+# from the upstream sensor module. The extra_state_attributes property was
+# rewritten in v8 for entity-based locations. See NOTICE for details.
 # As upstream-derived code is rewritten or removed, this comment should
 # be updated or removed accordingly.
 
@@ -51,6 +52,7 @@ class WXWatcherSensor(CoordinatorEntity):
         super().__init__(hass.data[DOMAIN][entry.entry_id][COORDINATOR])
         self._config = entry
         self._key = sensor_description.key
+        self._hass = hass
 
         self._attr_icon = sensor_description.icon
         self._attr_name = f"{entry.data.get(CONF_NAME, DOMAIN)} {sensor_description.name}"
@@ -77,14 +79,18 @@ class WXWatcherSensor(CoordinatorEntity):
 
         locations = self._config.data.get(CONF_LOCATIONS, [])
         if locations:
-            attrs["locations"] = [
-                {
-                    "name": loc.get("name", ""),
-                    "type": loc.get("type", ""),
-                    "mode": loc.get("mode", ""),
-                }
-                for loc in locations
-            ]
+            attrs["locations"] = []
+            for loc in locations:
+                entity_id = loc.get("ha_zone") or loc.get("tracker", "")
+                state = self._hass.states.get(entity_id)
+                attrs["locations"].append(
+                    {
+                        "entity": entity_id,
+                        "name": state.name if state else entity_id,
+                        "type": loc.get("type", ""),
+                        "mode": loc.get("mode", ""),
+                    }
+                )
 
         attrs[ATTR_ATTRIBUTION] = ATTRIBUTION
         return attrs

--- a/custom_components/wx_watcher/strings.json
+++ b/custom_components/wx_watcher/strings.json
@@ -12,39 +12,64 @@
       },
       "locations": {
         "title": "Locations",
-        "description": "Current locations: {location_list}\n\nAdd a location or finish setup.",
+        "description": "Current locations: {location_list}\n\nAdd, edit, or remove a location, or finish setup.",
         "data": {
           "action": "What would you like to do?"
         }
       },
       "add_static": {
         "title": "Add Static Location",
-        "description": "Add a fixed location that is always monitored. Zone mode includes all alerts listed for your NWS zone (broader coverage). Point mode only includes alerts whose polygon covers your exact coordinates (more precise).",
+        "description": "Select an HA zone to monitor. NWS zone IDs are automatically resolved from the zone's GPS coordinates. You can edit them after resolution.",
         "data": {
-          "name": "Location name",
-          "source": "How to specify location",
+          "ha_zone": "Home Assistant zone",
           "mode": "Query mode",
-          "gps": "GPS coordinates (lat,lon)",
-          "zone": "NWS Zone ID(s) — comma-separated",
-          "ha_zone": "Home Assistant zone"
+          "zone": "NWS Zone IDs (auto-resolved)"
         }
       },
       "add_tracked": {
         "title": "Add Tracked Device",
-        "description": "Add a device tracker to receive alerts for wherever the device is located.",
+        "description": "Select a device tracker to receive alerts wherever the device is located.",
         "data": {
-          "name": "Location name",
           "tracker": "Device tracker",
           "mode": "Query mode"
+        }
+      },
+      "edit_location": {
+        "title": "Edit Location",
+        "description": "Select a location to edit.",
+        "data": {
+          "location_index": "Location"
+        }
+      },
+      "edit_static": {
+        "title": "Edit Static Location",
+        "description": "Edit the HA zone and query mode. NWS zone IDs are automatically resolved from the zone's GPS coordinates.",
+        "data": {
+          "ha_zone": "Home Assistant zone",
+          "mode": "Query mode",
+          "zone": "NWS Zone IDs (auto-resolved)"
+        }
+      },
+      "edit_tracked": {
+        "title": "Edit Tracked Device",
+        "description": "Edit the device tracker and query mode.",
+        "data": {
+          "tracker": "Device tracker",
+          "mode": "Query mode"
+        }
+      },
+      "remove_location": {
+        "title": "Remove Location",
+        "description": "Select a location to remove.",
+        "data": {
+          "location_index": "Location"
         }
       }
     },
     "error": {
-      "no_zone_or_gps": "Zone mode requires either GPS coordinates (for auto-resolution) or manual zone IDs",
       "zone_resolve_failed": "Could not resolve GPS coordinates to NWS zones",
       "zone_no_gps": "Selected zone does not have GPS coordinates",
       "no_zone_selected": "No zone selected",
-      "no_tracker_selected": "No device tracker selected",
       "tracker_not_found": "Device tracker not found"
     }
   },
@@ -52,39 +77,64 @@
     "step": {
       "init": {
         "title": "WX Watcher Options",
-        "description": "Current locations: {location_list}\n\nAdd a location or save changes.",
+        "description": "Current locations: {location_list}\n\nAdd, edit, or remove a location, or save changes.",
         "data": {
           "action": "What would you like to do?"
         }
       },
       "add_static": {
         "title": "Add Static Location",
-        "description": "Add a fixed location that is always monitored.",
+        "description": "Select an HA zone to monitor. NWS zone IDs are automatically resolved from the zone's GPS coordinates. You can edit them after resolution.",
         "data": {
-          "name": "Location name",
-          "source": "How to specify location",
+          "ha_zone": "Home Assistant zone",
           "mode": "Query mode",
-          "gps": "GPS coordinates (lat,lon)",
-          "zone": "NWS Zone ID(s) — comma-separated",
-          "ha_zone": "Home Assistant zone"
+          "zone": "NWS Zone IDs (auto-resolved)"
         }
       },
       "add_tracked": {
         "title": "Add Tracked Device",
-        "description": "Add a device tracker to receive alerts for wherever the device is located.",
+        "description": "Select a device tracker to receive alerts wherever the device is located.",
         "data": {
-          "name": "Location name",
           "tracker": "Device tracker",
           "mode": "Query mode"
+        }
+      },
+      "edit_location": {
+        "title": "Edit Location",
+        "description": "Select a location to edit.",
+        "data": {
+          "location_index": "Location"
+        }
+      },
+      "edit_static": {
+        "title": "Edit Static Location",
+        "description": "Edit the HA zone and query mode. NWS zone IDs are automatically resolved from the zone's GPS coordinates.",
+        "data": {
+          "ha_zone": "Home Assistant zone",
+          "mode": "Query mode",
+          "zone": "NWS Zone IDs (auto-resolved)"
+        }
+      },
+      "edit_tracked": {
+        "title": "Edit Tracked Device",
+        "description": "Edit the device tracker and query mode.",
+        "data": {
+          "tracker": "Device tracker",
+          "mode": "Query mode"
+        }
+      },
+      "remove_location": {
+        "title": "Remove Location",
+        "description": "Select a location to remove.",
+        "data": {
+          "location_index": "Location"
         }
       }
     },
     "error": {
-      "no_zone_or_gps": "Zone mode requires either GPS coordinates (for auto-resolution) or manual zone IDs",
       "zone_resolve_failed": "Could not resolve GPS coordinates to NWS zones",
       "zone_no_gps": "Selected zone does not have GPS coordinates",
       "no_zone_selected": "No zone selected",
-      "no_tracker_selected": "No device tracker selected",
       "tracker_not_found": "Device tracker not found"
     }
   }

--- a/custom_components/wx_watcher/translations/en.json
+++ b/custom_components/wx_watcher/translations/en.json
@@ -12,39 +12,64 @@
       },
       "locations": {
         "title": "Locations",
-        "description": "Current locations: {location_list}\n\nAdd a location or finish setup.",
+        "description": "Current locations: {location_list}\n\nAdd, edit, or remove a location, or finish setup.",
         "data": {
           "action": "What would you like to do?"
         }
       },
       "add_static": {
         "title": "Add Static Location",
-        "description": "Add a fixed location that is always monitored. Zone mode includes all alerts listed for your NWS zone (broader coverage). Point mode only includes alerts whose polygon covers your exact coordinates (more precise).",
+        "description": "Select an HA zone to monitor. NWS zone IDs are automatically resolved from the zone's GPS coordinates. You can edit them after resolution.",
         "data": {
-          "name": "Location name",
-          "source": "How to specify location",
+          "ha_zone": "Home Assistant zone",
           "mode": "Query mode",
-          "gps": "GPS coordinates (lat,lon)",
-          "zone": "NWS Zone ID(s) — comma-separated",
-          "ha_zone": "Home Assistant zone"
+          "zone": "NWS Zone IDs (auto-resolved)"
         }
       },
       "add_tracked": {
         "title": "Add Tracked Device",
-        "description": "Add a device tracker to receive alerts for wherever the device is located.",
+        "description": "Select a device tracker to receive alerts wherever the device is located.",
         "data": {
-          "name": "Location name",
           "tracker": "Device tracker",
           "mode": "Query mode"
+        }
+      },
+      "edit_location": {
+        "title": "Edit Location",
+        "description": "Select a location to edit.",
+        "data": {
+          "location_index": "Location"
+        }
+      },
+      "edit_static": {
+        "title": "Edit Static Location",
+        "description": "Edit the HA zone and query mode. NWS zone IDs are automatically resolved from the zone's GPS coordinates.",
+        "data": {
+          "ha_zone": "Home Assistant zone",
+          "mode": "Query mode",
+          "zone": "NWS Zone IDs (auto-resolved)"
+        }
+      },
+      "edit_tracked": {
+        "title": "Edit Tracked Device",
+        "description": "Edit the device tracker and query mode.",
+        "data": {
+          "tracker": "Device tracker",
+          "mode": "Query mode"
+        }
+      },
+      "remove_location": {
+        "title": "Remove Location",
+        "description": "Select a location to remove.",
+        "data": {
+          "location_index": "Location"
         }
       }
     },
     "error": {
-      "no_zone_or_gps": "Zone mode requires either GPS coordinates (for auto-resolution) or manual zone IDs",
       "zone_resolve_failed": "Could not resolve GPS coordinates to NWS zones",
       "zone_no_gps": "Selected zone does not have GPS coordinates",
       "no_zone_selected": "No zone selected",
-      "no_tracker_selected": "No device tracker selected",
       "tracker_not_found": "Device tracker not found"
     }
   },
@@ -52,39 +77,64 @@
     "step": {
       "init": {
         "title": "WX Watcher Options",
-        "description": "Current locations: {location_list}\n\nAdd a location or save changes.",
+        "description": "Current locations: {location_list}\n\nAdd, edit, or remove a location, or save changes.",
         "data": {
           "action": "What would you like to do?"
         }
       },
       "add_static": {
         "title": "Add Static Location",
-        "description": "Add a fixed location that is always monitored.",
+        "description": "Select an HA zone to monitor. NWS zone IDs are automatically resolved from the zone's GPS coordinates. You can edit them after resolution.",
         "data": {
-          "name": "Location name",
-          "source": "How to specify location",
+          "ha_zone": "Home Assistant zone",
           "mode": "Query mode",
-          "gps": "GPS coordinates (lat,lon)",
-          "zone": "NWS Zone ID(s) — comma-separated",
-          "ha_zone": "Home Assistant zone"
+          "zone": "NWS Zone IDs (auto-resolved)"
         }
       },
       "add_tracked": {
         "title": "Add Tracked Device",
-        "description": "Add a device tracker to receive alerts for wherever the device is located.",
+        "description": "Select a device tracker to receive alerts wherever the device is located.",
         "data": {
-          "name": "Location name",
           "tracker": "Device tracker",
           "mode": "Query mode"
+        }
+      },
+      "edit_location": {
+        "title": "Edit Location",
+        "description": "Select a location to edit.",
+        "data": {
+          "location_index": "Location"
+        }
+      },
+      "edit_static": {
+        "title": "Edit Static Location",
+        "description": "Edit the HA zone and query mode. NWS zone IDs are automatically resolved from the zone's GPS coordinates.",
+        "data": {
+          "ha_zone": "Home Assistant zone",
+          "mode": "Query mode",
+          "zone": "NWS Zone IDs (auto-resolved)"
+        }
+      },
+      "edit_tracked": {
+        "title": "Edit Tracked Device",
+        "description": "Edit the device tracker and query mode.",
+        "data": {
+          "tracker": "Device tracker",
+          "mode": "Query mode"
+        }
+      },
+      "remove_location": {
+        "title": "Remove Location",
+        "description": "Select a location to remove.",
+        "data": {
+          "location_index": "Location"
         }
       }
     },
     "error": {
-      "no_zone_or_gps": "Zone mode requires either GPS coordinates (for auto-resolution) or manual zone IDs",
       "zone_resolve_failed": "Could not resolve GPS coordinates to NWS zones",
       "zone_no_gps": "Selected zone does not have GPS coordinates",
       "no_zone_selected": "No zone selected",
-      "no_tracker_selected": "No device tracker selected",
       "tracker_not_found": "Device tracker not found"
     }
   }

--- a/custom_components/wx_watcher/vtec/__init__.py
+++ b/custom_components/wx_watcher/vtec/__init__.py
@@ -1,0 +1,44 @@
+"""VTEC parsing and mapping package.
+
+Provides strict VTEC string parsing, specification code tables, and
+human-readable code inflation. Designed to be splittable as a standalone
+package — no Home Assistant dependencies.
+"""
+
+from custom_components.wx_watcher.vtec.codes import (
+    VTEC_ACTION_CODES,
+    VTEC_ACTION_NAMES,
+    VTEC_CLASS,
+    VTEC_PHENOMENA_CODES,
+    VTEC_PHENOMENA_NAMES,
+    VTEC_SIGNIFICANCE_CODES,
+    VTEC_SIGNIFICANCE_NAMES,
+    VTEC_STATUS_CODES,
+)
+from custom_components.wx_watcher.vtec.mapper import (
+    action_name,
+    describe_action,
+    describe_significance,
+    phenomena_name,
+    significance_name,
+)
+from custom_components.wx_watcher.vtec.parser import VTECParseError, VTECTokens, parse_vtec
+
+__all__ = [
+    "VTEC_ACTION_CODES",
+    "VTEC_ACTION_NAMES",
+    "VTEC_CLASS",
+    "VTEC_PHENOMENA_CODES",
+    "VTEC_PHENOMENA_NAMES",
+    "VTEC_SIGNIFICANCE_CODES",
+    "VTEC_SIGNIFICANCE_NAMES",
+    "VTEC_STATUS_CODES",
+    "VTECParseError",
+    "VTECTokens",
+    "action_name",
+    "describe_action",
+    "describe_significance",
+    "parse_vtec",
+    "phenomena_name",
+    "significance_name",
+]

--- a/custom_components/wx_watcher/vtec/codes.py
+++ b/custom_components/wx_watcher/vtec/codes.py
@@ -1,0 +1,127 @@
+"""VTEC specification code tables.
+
+Reference tables derived from pyIEM (akrherz/pyIEM, src/pyiem/nws/vtec.py),
+which itself references NWS Instruction 10-1703
+(https://www.weather.gov/media/directives/010_pdfs/pd01017003curr.pdf).
+"""
+
+import re
+
+VTEC_RE = (
+    r"(/([A-Z])\.([A-Z]+)\.([A-Z]+)\.([A-Z]+)\.([A-Z])\."
+    r"([0-9]+)\.([0-9TZ]+)-([0-9TZ]+)/)"
+)
+
+VTEC_CLASS: dict[str, str] = {
+    "O": "Operational",
+    "T": "Test",
+    "E": "Experimental",
+    "X": "Experimental VTEC",
+}
+
+VTEC_STATUS_CODES: frozenset[str] = frozenset(VTEC_CLASS)
+
+VTEC_ACTION_NAMES: dict[str, str] = {
+    "NEW": "issues",
+    "CON": "continues",
+    "EXA": "expands area to include",
+    "EXT": "extends time of",
+    "EXB": "extends time and expands area to include",
+    "UPG": "issues upgrade to",
+    "CAN": "cancels",
+    "EXP": "expires",
+    "ROU": "routine",
+    "COR": "corrects",
+}
+
+VTEC_ACTION_CODES: frozenset[str] = frozenset(VTEC_ACTION_NAMES)
+
+VTEC_SIGNIFICANCE_NAMES: dict[str, str] = {
+    "W": "Warning",
+    "A": "Watch",
+    "Y": "Advisory",
+    "S": "Statement",
+    "O": "Outlook",
+    "N": "Synopsis",
+    "F": "Forecast",
+}
+
+VTEC_SIGNIFICANCE_CODES: frozenset[str] = frozenset(VTEC_SIGNIFICANCE_NAMES)
+
+VTEC_PHENOMENA_NAMES: dict[str, str] = {
+    "AF": "Ashfall",
+    "AS": "Air Stagnation",
+    "BH": "Beach Hazard",
+    "BS": "Blowing Snow",
+    "BW": "Brisk Wind",
+    "BZ": "Blizzard",
+    "CF": "Coastal Flood",
+    "CW": "Cold Weather",
+    "DF": "Debris Flow",
+    "DS": "Dust Storm",
+    "DU": "Blowing Dust",
+    "EC": "Extreme Cold",
+    "EH": "Excessive Heat",
+    "EW": "Extreme Wind",
+    "FA": "Flood",
+    "FF": "Flash Flood",
+    "FG": "Dense Fog",
+    "FL": "Flood",
+    "FR": "Frost",
+    "FW": "Red Flag",
+    "FZ": "Freeze",
+    "UP": "Freezing Spray",
+    "GL": "Gale",
+    "HF": "Hurricane Force Wind",
+    "HI": "Inland Hurricane",
+    "HS": "Heavy Snow",
+    "HT": "Heat",
+    "HU": "Hurricane",
+    "HW": "High Wind",
+    "HY": "Hydrologic",
+    "HZ": "Hard Freeze",
+    "IP": "Sleet",
+    "IS": "Ice Storm",
+    "LB": "Lake Effect Snow and Blowing Snow",
+    "LE": "Lake Effect Snow",
+    "LO": "Low Water",
+    "LS": "Lakeshore Flood",
+    "LW": "Lake Wind",
+    "MA": "Marine",
+    "MF": "Marine Dense Fog",
+    "MH": "Marine Ashfall",
+    "MS": "Marine Dense Smoke",
+    "RB": "Small Craft for Rough",
+    "RP": "Rip Currents",
+    "SB": "Snow and Blowing",
+    "SC": "Small Craft",
+    "SE": "Hazardous Seas",
+    "SI": "Small Craft for Winds",
+    "SM": "Dense Smoke",
+    "SN": "Snow",
+    "SQ": "Snow Squall",
+    "SR": "Storm",
+    "SS": "Storm Surge",
+    "SU": "High Surf",
+    "SV": "Severe Thunderstorm",
+    "SW": "Small Craft for Hazardous Seas",
+    "TI": "Inland Tropical Storm",
+    "TO": "Tornado",
+    "TR": "Tropical Storm",
+    "TS": "Tsunami",
+    "TY": "Typhoon",
+    "WC": "Wind Chill",
+    "WI": "Wind",
+    "WS": "Winter Storm",
+    "WW": "Winter Weather",
+    "XH": "Extreme Heat",
+    "ZF": "Freezing Fog",
+    "ZR": "Freezing Rain",
+}
+
+VTEC_PHENOMENA_CODES: frozenset[str] = frozenset(VTEC_PHENOMENA_NAMES)
+
+VTEC_TIMESTAMP_UNDEFINED = "00000000T0000Z"
+VTEC_TIMESTAMP_FORMAT = "%y%m%dT%H%MZ"
+VTEC_OFFICE_RE = re.compile(r"^[A-Z]{4}$")
+VTEC_PHENOMENA_RE = re.compile(r"^[A-Z]{2}$")

--- a/custom_components/wx_watcher/vtec/mapper.py
+++ b/custom_components/wx_watcher/vtec/mapper.py
@@ -1,0 +1,44 @@
+"""VTEC code mapper — inflates raw codes to human-readable strings.
+
+All functions return the raw code string as a fallback for unknown inputs.
+No exceptions are raised from this module — it is display logic, not
+safety-critical.
+"""
+
+from custom_components.wx_watcher.vtec.codes import (
+    VTEC_ACTION_NAMES,
+    VTEC_PHENOMENA_NAMES,
+    VTEC_SIGNIFICANCE_NAMES,
+)
+from custom_components.wx_watcher.vtec.parser import VTECTokens
+
+
+def significance_name(code: str) -> str:
+    """Return the human-readable name for a VTEC significance code."""
+    return VTEC_SIGNIFICANCE_NAMES.get(code, code)
+
+
+def action_name(code: str) -> str:
+    """Return the human-readable verb for a VTEC action code."""
+    return VTEC_ACTION_NAMES.get(code, code)
+
+
+def phenomena_name(code: str) -> str:
+    """Return the human-readable name for a VTEC phenomena code."""
+    return VTEC_PHENOMENA_NAMES.get(code, code)
+
+
+def describe_significance(tokens: VTECTokens) -> str:
+    """Return '{phenomena_name} {significance_name}' for the token pair.
+
+    Special case: phenomena FW + significance A → 'Fire Weather Watch'
+    (matches pyIEM's get_ps_string convention).
+    """
+    if tokens.significance == "A" and tokens.phenomena == "FW":
+        return "Fire Weather Watch"
+    return f"{phenomena_name(tokens.phenomena)} {significance_name(tokens.significance)}"
+
+
+def describe_action(tokens: VTECTokens) -> str:
+    """Return '{action_name} {describe_significance}' for the token set."""
+    return f"{action_name(tokens.action)} {describe_significance(tokens)}"

--- a/custom_components/wx_watcher/vtec/parser.py
+++ b/custom_components/wx_watcher/vtec/parser.py
@@ -1,0 +1,164 @@
+"""VTEC string parser with strict validation.
+
+Parses a raw VTEC string into a VTECTokens NamedTuple, validating every
+field against the NWS VTEC specification. Raises VTECParseError on any
+deviation — this is safety-critical weather alert data and silent
+misclassification is unacceptable.
+"""
+
+from datetime import UTC, datetime
+import logging
+import re
+from typing import NamedTuple
+
+from custom_components.wx_watcher.vtec.codes import (
+    VTEC_ACTION_CODES,
+    VTEC_OFFICE_RE,
+    VTEC_PHENOMENA_CODES,
+    VTEC_PHENOMENA_RE,
+    VTEC_RE,
+    VTEC_SIGNIFICANCE_CODES,
+    VTEC_STATUS_CODES,
+    VTEC_TIMESTAMP_FORMAT,
+    VTEC_TIMESTAMP_UNDEFINED,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class VTECParseError(ValueError):
+    """Raised when a VTEC string fails spec validation."""
+
+
+class VTECTokens(NamedTuple):
+    """Parsed and validated VTEC fields — all raw codes, no inflation."""
+
+    status: str
+    action: str
+    office: str
+    phenomena: str
+    significance: str
+    etn: int
+    begints: str
+    endts: str
+
+
+def parse_vtec(vtec_string: str) -> VTECTokens:
+    """Parse and strictly validate a VTEC string.
+
+    Returns VTECTokens with all fields validated against the spec.
+    Raises VTECParseError on any deviation from the expected format.
+    """
+    match = re.match(VTEC_RE, vtec_string)
+    if not match:
+        raise VTECParseError(f"VTEC string does not match expected format: {vtec_string!r}")
+
+    status = match.group(2)
+    action = match.group(3)
+    office = match.group(4)
+    phenomena = match.group(5)
+    significance = match.group(6)
+    etn_raw = match.group(7)
+    begints = match.group(8)
+    endts = match.group(9)
+
+    _validate_status(vtec_string, status)
+    _validate_action(vtec_string, action)
+    _validate_office(vtec_string, office)
+    _validate_phenomena(vtec_string, phenomena)
+    _validate_significance(vtec_string, significance)
+    etn = _validate_etn(vtec_string, etn_raw)
+    _validate_timestamp(vtec_string, begints, "begin")
+    _validate_timestamp(vtec_string, endts, "end")
+
+    return VTECTokens(
+        status=status,
+        action=action,
+        office=office,
+        phenomena=phenomena,
+        significance=significance,
+        etn=etn,
+        begints=begints,
+        endts=endts,
+    )
+
+
+def _validate_status(vtec_string: str, status: str) -> None:
+    if status not in VTEC_STATUS_CODES:
+        raise VTECParseError(
+            f"Invalid VTEC status {status!r} in {vtec_string!r}; "
+            f"expected one of {sorted(VTEC_STATUS_CODES)}"
+        )
+
+
+def _validate_action(vtec_string: str, action: str) -> None:
+    if action not in VTEC_ACTION_CODES:
+        raise VTECParseError(
+            f"Invalid VTEC action {action!r} in {vtec_string!r}; "
+            f"expected one of {sorted(VTEC_ACTION_CODES)}"
+        )
+
+
+def _validate_office(vtec_string: str, office: str) -> None:
+    if not VTEC_OFFICE_RE.match(office):
+        raise VTECParseError(
+            f"Invalid VTEC office {office!r} in {vtec_string!r}; "
+            f"expected 4 uppercase letters (e.g. KPSR)"
+        )
+
+
+def _validate_phenomena(vtec_string: str, phenomena: str) -> None:
+    if not VTEC_PHENOMENA_RE.match(phenomena):
+        raise VTECParseError(
+            f"Invalid VTEC phenomena {phenomena!r} in {vtec_string!r}; "
+            f"expected 2 uppercase letters (e.g. EH)"
+        )
+    if phenomena not in VTEC_PHENOMENA_CODES:
+        _LOGGER.warning(
+            "Unknown VTEC phenomena code %r in %r — not in known codes list; "
+            "parsing will proceed but this may indicate a new NWS phenomena code",
+            phenomena,
+            vtec_string,
+        )
+
+
+def _validate_significance(vtec_string: str, significance: str) -> None:
+    if significance not in VTEC_SIGNIFICANCE_CODES:
+        raise VTECParseError(
+            f"Invalid VTEC significance {significance!r} in {vtec_string!r}; "
+            f"expected one of {sorted(VTEC_SIGNIFICANCE_CODES)}"
+        )
+
+
+def _validate_etn(vtec_string: str, etn_raw: str) -> int:
+    try:
+        etn = int(etn_raw)
+    except ValueError as err:
+        raise VTECParseError(
+            f"Invalid VTEC ETN {etn_raw!r} in {vtec_string!r}; expected non-negative integer"
+        ) from err
+    if etn < 0:
+        raise VTECParseError(
+            f"Negative VTEC ETN {etn} in {vtec_string!r}; expected non-negative integer"
+        )
+    return etn
+
+
+def _validate_timestamp(vtec_string: str, ts: str, label: str) -> None:
+    if ts == VTEC_TIMESTAMP_UNDEFINED:
+        return
+    try:
+        dt = datetime.strptime(ts, VTEC_TIMESTAMP_FORMAT)
+    except ValueError as err:
+        raise VTECParseError(
+            f"Invalid VTEC {label} timestamp {ts!r} in {vtec_string!r}; "
+            f"expected format {VTEC_TIMESTAMP_FORMAT!r} or "
+            f"sentinel {VTEC_TIMESTAMP_UNDEFINED!r}"
+        ) from err
+    dt = dt.replace(tzinfo=UTC)
+    if dt.year < 1971:
+        raise VTECParseError(
+            f"VTEC {label} timestamp {ts!r} in {vtec_string!r} resolves to "
+            f"year {dt.year}; years before 1971 are rejected "
+            f"(known NWS data bug)"
+        )

--- a/docs/v8_changes.md
+++ b/docs/v8_changes.md
@@ -1,0 +1,51 @@
+# WX Watcher v8 Changes
+
+## Entity-Based Locations
+
+Locations are now defined by Home Assistant entities instead of free-text names:
+
+- **Static locations** are HA zone entities (e.g., `zone.home`, `zone.work`)
+- **Tracked locations** are device tracker entities (e.g., `device_tracker.phone`)
+
+The free-text `name` field has been removed. Friendly names are derived from
+entity state at display time.
+
+## Event Source Data
+
+Event `sources` now use entity IDs:
+
+- Static: `{"ha_zone": "zone.home", "mode": "zone"}`
+- Tracked: `{"tracker": "device_tracker.phone", "mode": "point"}`
+
+The `location` key has been removed.
+
+## Tracker Skip Optimization
+
+When a tracked device's state indicates it is inside a static location's HA zone
+(e.g., device_tracker state is `"home"` when `zone.home` is a static location),
+the coordinator skips the tracked device's NWS API query entirely. The static
+location's zone query is a superset — it already covers the area.
+
+This means:
+
+- When phone is at home: only the home zone query runs. Events carry
+  `ha_zone: zone.home` in sources, never both `ha_zone` and `tracker`.
+- When phone is away: both queries run. Home events carry `ha_zone`,
+  phone events carry `tracker`. These are different alerts (different IDs)
+  for different geographic areas.
+
+## Config Flow Changes
+
+- Removed manual GPS and manual NWS zone ID source options
+- All static locations start from an HA zone entity
+- NWS zone IDs are auto-resolved but editable via the form
+- Zone IDs are deduplicated on save
+- Added edit and remove location flows
+- Device trackers use entity selector instead of raw dropdown
+- Location names are no longer configurable (derived from entity friendly name)
+
+## Blueprint
+
+See `blueprints/automation/wx_watcher_ticker.yaml` — routes alert notifications
+per-user based on static locations and tracked devices. Supports multiple zones
+and multiple devices per automation instance.

--- a/docs/v8_changes.md
+++ b/docs/v8_changes.md
@@ -49,3 +49,24 @@ This means:
 See `blueprints/automation/wx_watcher_ticker.yaml` — routes alert notifications
 per-user based on static locations and tracked devices. Supports multiple zones
 and multiple devices per automation instance.
+
+## VTEC Significance Field
+
+Alert events now include a `Significance` field extracted from the NWS VTEC string.
+This is the VTEC significance code — `W` for Warning, `A` for Watch, `Y` for
+Advisory, etc. — and is more reliable than text-matching the `Event` field.
+
+The blueprint now routes alerts by `Significance` code instead of substring
+matching on `Event`. Non-VTEC alerts (e.g., Air Quality Alert) have an empty
+`Significance` and fall to the default advisory category.
+
+A new `vtec/` subpackage provides strict VTEC parsing with full spec validation.
+Any deviation from the expected format raises `VTECParseError` with detailed
+diagnostics — no silent fallback on safety-critical alert data.
+
+## GPS Input Guard
+
+The coordinator now guards against empty or malformed GPS coordinates for
+tracked devices and point-mode locations. Previously, `_parse_gps()` could
+crash the entire update cycle on bad input. It now logs a warning and skips
+the affected location.

--- a/docs/v8_changes.md
+++ b/docs/v8_changes.md
@@ -22,7 +22,7 @@ The `location` key has been removed.
 ## Tracker Skip Optimization
 
 When a tracked device's state indicates it is inside a static location's HA zone
-(e.g., device_tracker state is `"home"` when `zone.home` is a static location),
+(e.g., device_tracker state is `"zone.home"` when `zone.home` is a static location),
 the coordinator skips the tracked device's NWS API query entirely. The static
 location's zone query is a superset — it already covers the area.
 
@@ -33,6 +33,12 @@ This means:
 - When phone is away: both queries run. Home events carry `ha_zone`,
   phone events carry `tracker`. These are different alerts (different IDs)
   for different geographic areas.
+
+> **Bug fix:** The initial implementation compared tracker state against
+> stripped zone slugs (`"home"`) instead of full entity IDs (`"zone.home"`),
+> so the skip check never matched. This has been corrected — the coordinator
+> now stores full entity IDs in the static-zone set, matching the format
+> that device_tracker entities report.
 
 ## Config Flow Changes
 

--- a/flake.nix
+++ b/flake.nix
@@ -127,7 +127,10 @@
               };
               check-json.enable = true;
               check-toml.enable = true;
-              check-yaml.enable = true;
+              check-yaml = {
+                enable = true;
+                excludes = [ "blueprints/" ];
+              };
               yamllint = {
                 enable = true;
                 entry = lib.mkForce "${yamllintWrapper}/bin/yamllint-wrapper";

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wx-watcher"
-version = "7.0.0"
+version = "8.0.0"
 requires-python = ">=3.13"
 
 [dependency-groups]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,6 +54,31 @@ def mock_aioclient():
         yield m
 
 
+@pytest.fixture(autouse=True)
+def mock_zones(hass):
+    """Mock HA zone entities for tests."""
+    hass.states.async_set(
+        "zone.home",
+        0,
+        {
+            "latitude": 33.25,
+            "longitude": -112.30,
+            "friendly_name": "Home",
+            "radius": 100,
+        },
+    )
+    hass.states.async_set(
+        "zone.work",
+        0,
+        {
+            "latitude": 33.45,
+            "longitude": -112.06,
+            "friendly_name": "Work",
+            "radius": 100,
+        },
+    )
+
+
 def get_fixture_path(filename: str, integration: str | None = None) -> pathlib.Path:
     """Get path of fixture."""
     if integration is None and "/" in filename and not filename.startswith("helpers/"):

--- a/tests/const.py
+++ b/tests/const.py
@@ -2,8 +2,8 @@
 
 from custom_components.wx_watcher.const import (
     CONF_LOCATION_GPS,
+    CONF_LOCATION_HA_ZONE,
     CONF_LOCATION_MODE,
-    CONF_LOCATION_NAME,
     CONF_LOCATION_TYPE,
     CONF_LOCATION_ZONE,
     LOCATION_MODE_POINT,
@@ -17,11 +17,11 @@ CONFIG_DATA = {
     "timeout": 120,
     "locations": [
         {
-            CONF_LOCATION_NAME: "Home",
             CONF_LOCATION_TYPE: LOCATION_TYPE_STATIC,
             CONF_LOCATION_MODE: LOCATION_MODE_ZONE,
             CONF_LOCATION_GPS: "33.25,-112.30",
             CONF_LOCATION_ZONE: "AZZ540,AZC013",
+            CONF_LOCATION_HA_ZONE: "zone.home",
         },
     ],
 }
@@ -32,18 +32,18 @@ CONFIG_DATA_TWO_LOCATIONS = {
     "timeout": 120,
     "locations": [
         {
-            CONF_LOCATION_NAME: "Home",
             CONF_LOCATION_TYPE: LOCATION_TYPE_STATIC,
             CONF_LOCATION_MODE: LOCATION_MODE_ZONE,
             CONF_LOCATION_GPS: "33.25,-112.30",
             CONF_LOCATION_ZONE: "AZZ540,AZC013",
+            CONF_LOCATION_HA_ZONE: "zone.home",
         },
         {
-            CONF_LOCATION_NAME: "Work",
             CONF_LOCATION_TYPE: LOCATION_TYPE_STATIC,
             CONF_LOCATION_MODE: LOCATION_MODE_POINT,
             CONF_LOCATION_GPS: "33.45,-112.06",
             CONF_LOCATION_ZONE: "",
+            CONF_LOCATION_HA_ZONE: "zone.work",
         },
     ],
 }
@@ -54,11 +54,11 @@ CONFIG_DATA_POINT_ONLY = {
     "timeout": 120,
     "locations": [
         {
-            CONF_LOCATION_NAME: "Home",
             CONF_LOCATION_TYPE: LOCATION_TYPE_STATIC,
             CONF_LOCATION_MODE: LOCATION_MODE_POINT,
             CONF_LOCATION_GPS: "33.25,-112.30",
             CONF_LOCATION_ZONE: "",
+            CONF_LOCATION_HA_ZONE: "zone.home",
         },
     ],
 }

--- a/tests/const.py
+++ b/tests/const.py
@@ -4,11 +4,13 @@ from custom_components.wx_watcher.const import (
     CONF_LOCATION_GPS,
     CONF_LOCATION_HA_ZONE,
     CONF_LOCATION_MODE,
+    CONF_LOCATION_TRACKER,
     CONF_LOCATION_TYPE,
     CONF_LOCATION_ZONE,
     LOCATION_MODE_POINT,
     LOCATION_MODE_ZONE,
     LOCATION_TYPE_STATIC,
+    LOCATION_TYPE_TRACKED,
 )
 
 CONFIG_DATA = {
@@ -59,6 +61,28 @@ CONFIG_DATA_POINT_ONLY = {
             CONF_LOCATION_GPS: "33.25,-112.30",
             CONF_LOCATION_ZONE: "",
             CONF_LOCATION_HA_ZONE: "zone.home",
+        },
+    ],
+}
+
+CONFIG_DATA_TRACKER_IN_STATIC_ZONE = {
+    "name": "WX Watcher",
+    "interval": 1,
+    "timeout": 120,
+    "locations": [
+        {
+            CONF_LOCATION_TYPE: LOCATION_TYPE_STATIC,
+            CONF_LOCATION_MODE: LOCATION_MODE_ZONE,
+            CONF_LOCATION_GPS: "33.25,-112.30",
+            CONF_LOCATION_ZONE: "AZZ540,AZC013",
+            CONF_LOCATION_HA_ZONE: "zone.home",
+        },
+        {
+            CONF_LOCATION_TYPE: LOCATION_TYPE_TRACKED,
+            CONF_LOCATION_MODE: LOCATION_MODE_POINT,
+            CONF_LOCATION_GPS: "",
+            CONF_LOCATION_ZONE: "",
+            CONF_LOCATION_TRACKER: "device_tracker.phone",
         },
     ],
 }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -50,7 +50,7 @@ def test_parse_alert():
             "response": "Execute",
             "parameters": {
                 "NWSheadline": ["TEST WARNING"],
-                "VTEC": ["/O.NEW.KTEST.TW.Y.0001.240719T1700Z-240721T0300Z/"],
+                "VTEC": ["/O.NEW.KTST.TW.Y.0001.240719T1700Z-240721T0300Z/"],
             },
         },
     }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,7 @@
 """Test NWS API client functions."""
 
+import logging
+
 from custom_components.wx_watcher.api import generate_id, parse_alert
 
 
@@ -62,6 +64,7 @@ def test_parse_alert():
     assert result["Severity"] == "Severe"
     assert result["_ugc"] == ["AZZ540", "AZC013"]
     assert result["VTECAction"] == "NEW"
+    assert result["Significance"] == "Y"
 
 
 def test_parse_alert_missing_properties():
@@ -79,3 +82,42 @@ def test_parse_alert_missing_id():
     }
     result = parse_alert(raw)
     assert result is None
+
+
+def test_parse_alert_no_vtec():
+    """Test parsing an alert with empty VTEC list."""
+    raw = {
+        "id": "https://api.weather.gov/alerts/urn:oid:no-vtec",
+        "type": "Feature",
+        "properties": {
+            "event": "Air Quality Alert",
+            "geocode": {"SAME": [], "UGC": []},
+            "parameters": {"NWSheadline": ["AIR QUALITY ALERT"], "VTEC": []},
+        },
+    }
+    result = parse_alert(raw)
+    assert result is not None
+    assert result["VTECAction"] is None
+    assert result["Significance"] == ""
+
+
+def test_parse_alert_bad_vtec(caplog):
+    """Test parsing an alert with malformed VTEC string."""
+    raw = {
+        "id": "https://api.weather.gov/alerts/urn:oid:bad-vtec",
+        "type": "Feature",
+        "properties": {
+            "event": "Test Alert",
+            "geocode": {"SAME": [], "UGC": []},
+            "parameters": {
+                "NWSheadline": ["TEST"],
+                "VTEC": ["NOT-A-VTEC-STRING"],
+            },
+        },
+    }
+    with caplog.at_level(logging.WARNING, logger="custom_components.wx_watcher.api"):
+        result = parse_alert(raw)
+    assert result is not None
+    assert result["VTECAction"] is None
+    assert result["Significance"] == ""
+    assert "Failed to parse VTEC" in caplog.text

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -11,8 +11,8 @@ from homeassistant.data_entry_flow import FlowResultType
 pytestmark = pytest.mark.asyncio
 
 
-async def test_form_zone(hass):
-    """Test we get the form and can create a zone entry."""
+async def test_form_static_zone(hass):
+    """Test we can create a static zone entry with auto-resolved zone IDs."""
     await setup.async_setup_component(hass, "persistent_notification", {})
     with patch("custom_components.wx_watcher.async_setup_entry", return_value=True):
         result = await hass.config_entries.flow.async_init(
@@ -20,27 +20,99 @@ async def test_form_zone(hass):
         )
         assert result["type"] == FlowResultType.FORM
 
-    user_data = {
-        "name": "Testing Alerts",
-        "interval": 1,
-        "timeout": 120,
-    }
-    with (
-        patch("custom_components.wx_watcher.async_setup_entry", return_value=True),
-        patch(
-            "custom_components.wx_watcher.config_flow.resolve_zones",
-            return_value=["AZZ540", "AZC013"],
-        ),
-    ):
+        user_data = {
+            "name": "Testing Alerts",
+            "interval": 1,
+            "timeout": 120,
+        }
         result = await hass.config_entries.flow.async_configure(result["flow_id"], user_data)
         await hass.async_block_till_done()
 
-    with (
-        patch("custom_components.wx_watcher.async_setup_entry", return_value=True),
-    ):
-        result2 = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"action": "add_static"}
+        )
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "add_static"
+
+        with patch(
+            "custom_components.wx_watcher.config_flow.resolve_zones",
+            return_value=["AZZ540", "AZC013"],
+        ):
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                {"ha_zone": "zone.home", "mode": "zone", "zone": ""},
+            )
+            assert result["type"] == FlowResultType.FORM
+            assert result["step_id"] == "locations"
+
+        result = await hass.config_entries.flow.async_configure(
             result["flow_id"], {"action": "done"}
         )
-        assert result2["type"] == "create_entry"
-        assert result2["title"] == "Testing Alerts"
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["title"] == "Testing Alerts"
+        assert len(result["data"]["locations"]) == 1
+        assert result["data"]["locations"][0]["ha_zone"] == "zone.home"
+        assert result["data"]["locations"][0]["zone"] == "AZC013,AZZ540"
+        assert result["data"]["locations"][0]["mode"] == "zone"
+        await hass.async_block_till_done()
+
+
+async def test_form_static_zone_with_manual_edit(hass):
+    """Test zone IDs can be manually provided on first submit."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    with patch("custom_components.wx_watcher.async_setup_entry", return_value=True):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        user_data = {"name": "Testing", "interval": 1, "timeout": 120}
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], user_data)
+        await hass.async_block_till_done()
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"action": "add_static"}
+        )
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"ha_zone": "zone.home", "mode": "zone", "zone": "AZZ540"},
+        )
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "locations"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"action": "done"}
+        )
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["data"]["locations"][0]["zone"] == "AZZ540"
+        await hass.async_block_till_done()
+
+
+async def test_form_static_point_mode(hass):
+    """Test point mode skips zone resolution."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    with patch("custom_components.wx_watcher.async_setup_entry", return_value=True):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        user_data = {"name": "Testing", "interval": 1, "timeout": 120}
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], user_data)
+        await hass.async_block_till_done()
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"action": "add_static"}
+        )
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"ha_zone": "zone.home", "mode": "point", "zone": ""},
+        )
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "locations"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"action": "done"}
+        )
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["data"]["locations"][0]["mode"] == "point"
+        assert result["data"]["locations"][0]["zone"] == ""
         await hass.async_block_till_done()

--- a/tests/test_coordinator_events.py
+++ b/tests/test_coordinator_events.py
@@ -57,7 +57,7 @@ async def _setup_entry(hass, mock_aioclient, config_data, entry_title="WX Watche
         domain=DOMAIN,
         title=entry_title,
         data=config_data,
-        version=3,
+        version=4,
     )
     entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(entry.entry_id)
@@ -127,8 +127,8 @@ class TestFirstPoll:
 
         heat_event = [e for e in events if e.data["ID"] == HEAT_ALERT_ID][0]
         sources = heat_event.data["sources"]
-        source_names = {s["location"] for s in sources}
-        assert "Home" in source_names
+        ha_zones = {s["ha_zone"] for s in sources if "ha_zone" in s}
+        assert "zone.home" in ha_zones
 
 
 class TestSecondPollNoChanges:
@@ -300,7 +300,7 @@ class TestPointMode:
         assert len(created) == 2
         for e in created:
             sources = e.data["sources"]
-            assert any(s["location"] == "Home" and s["mode"] == "point" for s in sources)
+            assert any(s.get("ha_zone") == "zone.home" and s["mode"] == "point" for s in sources)
 
 
 def load_fixture(filename):

--- a/tests/test_coordinator_events.py
+++ b/tests/test_coordinator_events.py
@@ -45,6 +45,7 @@ EXPECTED_ALERT_FIELDS = {
     "FormattedHeadline",
     "VTEC",
     "VTECAction",
+    "Significance",
     "References",
     "config_entry_id",
     "sources",

--- a/tests/test_coordinator_events.py
+++ b/tests/test_coordinator_events.py
@@ -14,7 +14,7 @@ from custom_components.wx_watcher.const import (
     EVENT_ALERT_UPDATED,
 )
 from tests.conftest import ZONE_URL
-from tests.const import CONFIG_DATA, CONFIG_DATA_POINT_ONLY
+from tests.const import CONFIG_DATA, CONFIG_DATA_POINT_ONLY, CONFIG_DATA_TRACKER_IN_STATIC_ZONE
 
 pytestmark = pytest.mark.asyncio
 
@@ -307,3 +307,60 @@ class TestPointMode:
 def load_fixture(filename):
     """Load a test fixture."""
     return pathlib.Path(__file__).parent.joinpath("fixtures", filename).read_text(encoding="utf8")
+
+
+class TestTrackerSkipOptimization:
+    """Tests for tracker-skip optimization when tracker is inside a static zone."""
+
+    async def test_tracker_in_static_zone_skipped(self, hass, mock_aioclient):
+        """Tracker inside a static zone should be skipped — only zone query fires."""
+        hass.states.async_set(
+            "device_tracker.phone",
+            "zone.home",
+            {"latitude": 33.25, "longitude": -112.30, "friendly_name": "Phone"},
+        )
+
+        mock_aioclient.get(ZONE_URL, status=200, body=load_fixture("api.json"))
+        mock_aioclient.get(ZONE_URL, status=200, body=load_fixture("api.json"))
+
+        events = []
+
+        def listener(event):
+            events.append(event)
+
+        hass.bus.async_listen(EVENT_ALERT_CREATED, listener)
+
+        await _setup_entry(hass, mock_aioclient, CONFIG_DATA_TRACKER_IN_STATIC_ZONE)
+
+        created = [e for e in events if e.event_type == EVENT_ALERT_CREATED]
+        assert len(created) == 2
+
+        for e in created:
+            sources = e.data["sources"]
+            assert any(s.get("ha_zone") == "zone.home" for s in sources)
+            assert not any(s.get("tracker") == "device_tracker.phone" for s in sources)
+
+    async def test_tracker_away_from_static_zone_not_skipped(self, hass, mock_aioclient):
+        """Tracker away from static zone should not be skipped — both queries fire."""
+        hass.states.async_set(
+            "device_tracker.phone",
+            "not_home",
+            {"latitude": 33.50, "longitude": -112.00, "friendly_name": "Phone"},
+        )
+
+        point_url = "https://api.weather.gov/alerts/active?point=33.5,-112.0"
+        mock_aioclient.get(ZONE_URL, status=200, body=load_fixture("api.json"))
+        mock_aioclient.get(ZONE_URL, status=200, body=load_fixture("api.json"))
+        mock_aioclient.get(point_url, status=200, body=load_fixture("api.json"))
+
+        events = []
+
+        def listener(event):
+            events.append(event)
+
+        hass.bus.async_listen(EVENT_ALERT_CREATED, listener)
+
+        await _setup_entry(hass, mock_aioclient, CONFIG_DATA_TRACKER_IN_STATIC_ZONE)
+
+        created = [e for e in events if e.event_type == EVENT_ALERT_CREATED]
+        assert len(created) >= 2

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -19,7 +19,7 @@ async def test_setup_entry(hass, mock_api, caplog):
             domain=DOMAIN,
             title="WX Watcher",
             data=CONFIG_DATA,
-            version=3,
+            version=4,
         )
 
         entry.add_to_hass(hass)
@@ -37,7 +37,7 @@ async def test_unload_entry(hass, mock_api):
         domain=DOMAIN,
         title="WX Watcher",
         data=CONFIG_DATA,
-        version=3,
+        version=4,
     )
 
     entry.add_to_hass(hass)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -17,7 +17,7 @@ async def test_sensor(hass, mock_api):
         domain=DOMAIN,
         title="WX Watcher",
         data=CONFIG_DATA,
-        version=3,
+        version=4,
     )
 
     entry.add_to_hass(hass)
@@ -36,6 +36,7 @@ async def test_sensor(hass, mock_api):
 
     loc_info = state.attributes["locations"]
     assert len(loc_info) == 1
+    assert loc_info[0]["entity"] == "zone.home"
     assert loc_info[0]["name"] == "Home"
     assert loc_info[0]["type"] == "static"
     assert loc_info[0]["mode"] == "zone"

--- a/tests/test_vtec.py
+++ b/tests/test_vtec.py
@@ -1,0 +1,253 @@
+"""Tests for the VTEC parsing and mapping package."""
+
+import logging
+
+import pytest
+
+from custom_components.wx_watcher.vtec import (
+    VTECParseError,
+    action_name,
+    describe_action,
+    describe_significance,
+    parse_vtec,
+    phenomena_name,
+    significance_name,
+)
+from custom_components.wx_watcher.vtec.codes import (
+    VTEC_ACTION_CODES,
+    VTEC_PHENOMENA_CODES,
+    VTEC_SIGNIFICANCE_CODES,
+)
+
+FIXTURE_VTEC = "/O.CON.KPSR.EH.W.0006.240719T1700Z-240721T0300Z/"
+TEST_DATA_VTEC = "/O.NEW.KTST.TW.Y.0001.240719T1700Z-240721T0300Z/"
+
+
+def _build_vtec(
+    status="O",
+    action="NEW",
+    office="KPSR",
+    phenomena="EH",
+    significance="W",
+    etn="0001",
+    begints="240719T1700Z",
+    endts="240721T0300Z",
+):
+    return f"/{status}.{action}.{office}.{phenomena}.{significance}.{etn}.{begints}-{endts}/"
+
+
+class TestParseValid:
+    """Tests for parsing valid VTEC strings."""
+
+    def test_parse_fixture_vtec(self):
+        """Full parse of api.json fixture VTEC string."""
+        tokens = parse_vtec(FIXTURE_VTEC)
+        assert tokens.status == "O"
+        assert tokens.action == "CON"
+        assert tokens.office == "KPSR"
+        assert tokens.phenomena == "EH"
+        assert tokens.significance == "W"
+        assert tokens.etn == 6
+        assert tokens.begints == "240719T1700Z"
+        assert tokens.endts == "240721T0300Z"
+
+    def test_parse_test_data_vtec(self):
+        """Parse test_api.py VTEC string with significance Y."""
+        tokens = parse_vtec(TEST_DATA_VTEC)
+        assert tokens.significance == "Y"
+        assert tokens.action == "NEW"
+        assert tokens.office == "KTST"
+        assert tokens.phenomena == "TW"
+        assert tokens.etn == 1
+
+    def test_parse_all_significance_codes(self):
+        """Every known significance code should parse successfully."""
+        for sig in VTEC_SIGNIFICANCE_CODES:
+            vtec = _build_vtec(significance=sig)
+            tokens = parse_vtec(vtec)
+            assert tokens.significance == sig
+
+    def test_parse_all_action_codes(self):
+        """Every known action code should parse successfully."""
+        for action in VTEC_ACTION_CODES:
+            vtec = _build_vtec(action=action)
+            tokens = parse_vtec(vtec)
+            assert tokens.action == action
+
+    def test_parse_all_known_phenomena(self):
+        """Every known phenomena code should parse successfully."""
+        for phen in VTEC_PHENOMENA_CODES:
+            vtec = _build_vtec(phenomena=phen)
+            tokens = parse_vtec(vtec)
+            assert tokens.phenomena == phen
+
+    def test_parse_undefined_begin_timestamp(self):
+        """Undefined begin timestamp sentinel should be accepted."""
+        vtec = _build_vtec(begints="00000000T0000Z")
+        tokens = parse_vtec(vtec)
+        assert tokens.begints == "00000000T0000Z"
+
+    def test_parse_undefined_end_timestamp(self):
+        """Undefined end timestamp sentinel should be accepted."""
+        vtec = _build_vtec(endts="00000000T0000Z")
+        tokens = parse_vtec(vtec)
+        assert tokens.endts == "00000000T0000Z"
+
+    def test_parse_both_undefined_timestamps(self):
+        """Both timestamps as undefined sentinels should be accepted."""
+        vtec = _build_vtec(begints="00000000T0000Z", endts="00000000T0000Z")
+        tokens = parse_vtec(vtec)
+        assert tokens.begints == "00000000T0000Z"
+        assert tokens.endts == "00000000T0000Z"
+
+
+class TestParseInvalid:
+    """Tests for VTECParseError on invalid VTEC strings."""
+
+    def test_parse_no_regex_match(self):
+        """Garbage string should raise VTECParseError."""
+        with pytest.raises(VTECParseError, match="does not match expected format"):
+            parse_vtec("not-a-vtec-string")
+
+    def test_parse_empty_string(self):
+        """Empty string should raise VTECParseError."""
+        with pytest.raises(VTECParseError, match="does not match expected format"):
+            parse_vtec("")
+
+    def test_parse_bad_status(self):
+        """Invalid status letter should raise VTECParseError."""
+        vtec = _build_vtec(status="Z")
+        with pytest.raises(VTECParseError, match="Invalid VTEC status"):
+            parse_vtec(vtec)
+
+    def test_parse_bad_action(self):
+        """Unknown action code should raise VTECParseError."""
+        vtec = _build_vtec(action="XXX")
+        with pytest.raises(VTECParseError, match="Invalid VTEC action"):
+            parse_vtec(vtec)
+
+    def test_parse_bad_office_short(self):
+        """Too-short office should raise VTECParseError."""
+        vtec = _build_vtec(office="KP")
+        with pytest.raises(VTECParseError, match="Invalid VTEC office"):
+            parse_vtec(vtec)
+
+    def test_parse_bad_office_lowercase(self):
+        """Lowercase office should fail regex match."""
+        vtec = _build_vtec(office="kpsr")
+        with pytest.raises(VTECParseError, match="does not match expected format"):
+            parse_vtec(vtec)
+
+    def test_parse_bad_significance(self):
+        """Unknown significance code should raise VTECParseError."""
+        vtec = _build_vtec(significance="Z")
+        with pytest.raises(VTECParseError, match="Invalid VTEC significance"):
+            parse_vtec(vtec)
+
+    def test_parse_invalid_begin_timestamp_format(self):
+        """Non-numeric begin timestamp should fail regex match."""
+        vtec = _build_vtec(begints="garbage")
+        with pytest.raises(VTECParseError, match="does not match expected format"):
+            parse_vtec(vtec)
+
+    def test_parse_invalid_end_timestamp_format(self):
+        """Non-numeric end timestamp should fail regex match."""
+        vtec = _build_vtec(endts="not-a-time")
+        with pytest.raises(VTECParseError, match="does not match expected format"):
+            parse_vtec(vtec)
+
+    def test_parse_pre1971_timestamp(self):
+        """Pre-1971 timestamp should raise VTECParseError."""
+        vtec = _build_vtec(begints="691231T0000Z")
+        with pytest.raises(VTECParseError, match="year 1969"):
+            parse_vtec(vtec)
+
+    def test_parse_bad_phenomena_format(self):
+        """3-character phenomena should raise VTECParseError."""
+        vtec = _build_vtec(phenomena="ABC")
+        with pytest.raises(VTECParseError, match="Invalid VTEC phenomena"):
+            parse_vtec(vtec)
+
+    def test_parse_bad_phenomena_lowercase(self):
+        """Lowercase phenomena should fail regex match."""
+        vtec = _build_vtec(phenomena="eh")
+        with pytest.raises(VTECParseError, match="does not match expected format"):
+            parse_vtec(vtec)
+
+    def test_parse_invalid_begin_timestamp_bad_month(self):
+        """Timestamp with invalid month should raise VTECParseError."""
+        vtec = _build_vtec(begints="241319T1700Z")
+        with pytest.raises(VTECParseError, match="begin timestamp"):
+            parse_vtec(vtec)
+
+    def test_parse_invalid_end_timestamp_bad_month(self):
+        """Timestamp with invalid month should raise VTECParseError."""
+        vtec = _build_vtec(endts="241319T1700Z")
+        with pytest.raises(VTECParseError, match="end timestamp"):
+            parse_vtec(vtec)
+
+
+class TestParseUnknownPhenomena:
+    """Tests for unknown phenomena code handling."""
+
+    def test_parse_unknown_phenomena_warns(self, caplog):
+        """Unknown 2-letter phenomena should parse with a warning."""
+        vtec = _build_vtec(phenomena="ZZ")
+        with caplog.at_level(logging.WARNING, logger="custom_components.wx_watcher.vtec.parser"):
+            tokens = parse_vtec(vtec)
+        assert tokens.phenomena == "ZZ"
+        assert "Unknown VTEC phenomena code 'ZZ'" in caplog.text
+
+
+class TestMapper:
+    """Tests for VTEC code mapper functions."""
+
+    def test_significance_name_known(self):
+        """Known significance codes should return human-readable names."""
+        assert significance_name("W") == "Warning"
+        assert significance_name("A") == "Watch"
+        assert significance_name("Y") == "Advisory"
+
+    def test_significance_name_unknown(self):
+        """Unknown significance code should return the raw code."""
+        assert significance_name("Z") == "Z"
+
+    def test_action_name_known(self):
+        """Known action codes should return human-readable verbs."""
+        assert action_name("NEW") == "issues"
+        assert action_name("CON") == "continues"
+        assert action_name("CAN") == "cancels"
+
+    def test_action_name_unknown(self):
+        """Unknown action code should return the raw code."""
+        assert action_name("XXX") == "XXX"
+
+    def test_phenomena_name_known(self):
+        """Known phenomena codes should return human-readable names."""
+        assert phenomena_name("EH") == "Excessive Heat"
+        assert phenomena_name("TO") == "Tornado"
+        assert phenomena_name("FF") == "Flash Flood"
+
+    def test_phenomena_name_unknown(self):
+        """Unknown phenomena code should return the raw code."""
+        assert phenomena_name("ZZ") == "ZZ"
+
+    def test_describe_significance(self):
+        """describe_significance should combine phenomena and significance names."""
+        tokens = parse_vtec(FIXTURE_VTEC)
+        assert describe_significance(tokens) == "Excessive Heat Warning"
+
+    def test_describe_significance_fw_watch(self):
+        """FW+A special case should return Fire Weather Watch."""
+        tokens = parse_vtec(_build_vtec(phenomena="FW", significance="A"))
+        assert describe_significance(tokens) == "Fire Weather Watch"
+
+    def test_describe_action(self):
+        """describe_action should combine action verb with significance description."""
+        tokens = parse_vtec(FIXTURE_VTEC)
+        assert describe_action(tokens) == "continues Excessive Heat Warning"
+
+    def test_describe_action_new(self):
+        """describe_action with NEW should use 'issues' verb."""
+        tokens = parse_vtec(_build_vtec(action="NEW"))
+        assert describe_action(tokens) == "issues Excessive Heat Warning"

--- a/uv.lock
+++ b/uv.lock
@@ -4956,7 +4956,7 @@ wheels = [
 
 [[package]]
 name = "wx-watcher"
-version = "7.0.0"
+version = "8.0.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

- **v8.0.0**: Redesigned integration using HA entity-based locations (zone entities for static, device_tracker for tracked), automatic NWS zone resolution, deduplicated alert events with source tracking, and combined zone API queries
- **VTEC parsing package**: New `vtec/` subpackage with strict VTEC string parsing, code tables, and human-readable mapping. Adds `Significance` field to alert events
- **Review fixes**: Fixed tracker-skip optimization bug (slug vs entity ID mismatch), added early empty-ha_zone validation guard, added tracker-skip tests, added blueprint `max` concurrency note

## Breaking Changes

- Config entries must be deleted and reconfigured — data model is incompatible
- Location names removed — locations defined by HA zone/device_tracker entities
- Event source data uses `ha_zone`/`tracker` keys instead of `location`
- Manual GPS and manual NWS zone ID source options removed

## Test Plan

- [x] 55/55 pytest passing
- [x] ruff + mypy clean
- [x] All pre-commit hooks passing
- [x] Tracker-skip optimization verified with new tests (skip when inside zone, no skip when away)

Assisted-by: GLM 5.1 via OpenCode