### PR TITLE
feat!: add number entities for interval/timeout, remove name form, show zone IDs

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -17,18 +17,17 @@ removed, those attribution comments should be updated or removed accordingly.
 Derived code by file:
   - __init__.py: setup/unload pattern, startup logging, user agent construction,
     coordinator storage pattern (from finity69x2/nws_alerts)
-  - const.py: API endpoint, constant naming conventions, default values,
-    event naming pattern (from finity69x2/nws_alerts, originally from
+  - const.py: API endpoint, constant naming conventions, event naming pattern
+    (from finity69x2/nws_alerts, originally from
     eracknaphobia/nws_custom_component)
   - api.py: generate_id() MD5->UUID algorithm, HTTP fetch pattern,
     alert field extraction from NWS API responses (from finity69x2/nws_alerts)
   - coordinator.py: DataUpdateCoordinator structure, _async_update_data pattern
-    with async_timeout + UpdateFailed, _get_tracker_gps (from finity69x2/nws_alerts)
+    with async_timeout + UpdateFailed (from finity69x2/nws_alerts)
   - sensor.py: SENSOR_TYPES dict, CoordinatorEntity class structure, state/
     device_info properties, async_setup_entry pattern
     (from finity69x2/nws_alerts)
   - manifest.json: structure and field names (from finity69x2/nws_alerts)
 
 The original nws_custom_component by eracknaphobia contributed the concept and
-initial API endpoint/constant definitions (API_ENDPOINT, USER_AGENT, DEFAULT_ICON,
-DEFAULT_NAME, CONF_ZONE_ID, ZONE_ID).
+initial API endpoint/constant definitions (API_ENDPOINT, USER_AGENT, DEFAULT_ICON).

--- a/custom_components/wx_watcher/__init__.py
+++ b/custom_components/wx_watcher/__init__.py
@@ -16,6 +16,7 @@ from homeassistant.helpers.instance_id import async_get as async_get_instance_id
 
 from .const import COORDINATOR, DOMAIN, ISSUE_URL, PLATFORMS, USER_AGENT, VERSION
 from .coordinator import AlertsDataUpdateCoordinator
+from .migration import async_migrate_entry as async_migrate_entry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -40,13 +41,14 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         user_agent=user_agent,
     )
 
-    await coordinator.async_refresh()
-
     hass.data[DOMAIN][config_entry.entry_id] = {
         COORDINATOR: coordinator,
     }
 
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
+
+    await coordinator.async_refresh()
+
     return True
 
 

--- a/custom_components/wx_watcher/api.py
+++ b/custom_components/wx_watcher/api.py
@@ -70,14 +70,14 @@ async def fetch_zone_alerts(
     session: aiohttp.ClientSession,
     user_agent: str,
     zone_ids: list[str],
-) -> list[dict[str, Any]]:
+) -> tuple[list[dict[str, Any]], str]:
     """Fetch active alerts for a combined set of zone IDs.
 
     The zone_ids list is joined with commas for a single ?zone= query.
-    Returns a list of raw alert dicts from the API response.
+    Returns a tuple of (raw alert features list, updated timestamp string).
     """
     if not zone_ids:
-        return []
+        return [], ""
 
     url = f"{API_ENDPOINT}/alerts/active?zone={','.join(zone_ids)}"
     return await _fetch_alerts(session, user_agent, url, f"zones {zone_ids}")
@@ -88,10 +88,10 @@ async def fetch_point_alerts(
     user_agent: str,
     lat: float,
     lon: float,
-) -> list[dict[str, Any]]:
+) -> tuple[list[dict[str, Any]], str]:
     """Fetch active alerts for a GPS point.
 
-    Returns a list of raw alert dicts from the API response.
+    Returns a tuple of (raw alert features list, updated timestamp string).
     """
     url = f"{API_ENDPOINT}/alerts/active?point={lat},{lon}"
     return await _fetch_alerts(session, user_agent, url, f"point {lat},{lon}")
@@ -102,8 +102,11 @@ async def _fetch_alerts(
     user_agent: str,
     url: str,
     desc: str,
-) -> list[dict[str, Any]]:
-    """Fetch and return raw alert features from an NWS API URL."""
+) -> tuple[list[dict[str, Any]], str]:
+    """Fetch and return raw alert features from an NWS API URL.
+
+    Returns a tuple of (features list, updated timestamp string).
+    """
     headers = {"User-Agent": user_agent, "Accept": "application/geo+json"}
     _LOGGER.debug("Fetching alerts for %s from %s", desc, url)
 
@@ -111,8 +114,9 @@ async def _fetch_alerts(
         if r.status == 200:
             data = await r.json()
             features = data.get("features", [])
+            updated = data.get("updated", "")
             _LOGGER.debug("Got %d alerts for %s", len(features), desc)
-            return features
+            return features, updated
         msg = f"Problem fetching alerts for {desc}: ({r.status}) {r.reason}"
         _LOGGER.warning(msg)
         raise NWSApiError(msg)

--- a/custom_components/wx_watcher/config_flow.py
+++ b/custom_components/wx_watcher/config_flow.py
@@ -9,7 +9,6 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry, ConfigFlowResult
-from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.instance_id import async_get as async_get_instance_id
@@ -68,7 +67,11 @@ def _location_display(hass: HomeAssistant, loc: dict[str, Any]) -> str:
     entity_id = loc.get(CONF_LOCATION_HA_ZONE) or loc.get(CONF_LOCATION_TRACKER, "")
     state = hass.states.get(entity_id)
     name = state.name if state else entity_id
-    return f"{name} ({loc[CONF_LOCATION_TYPE]}, {loc[CONF_LOCATION_MODE]})"
+    display = f"{name} ({loc[CONF_LOCATION_TYPE]}, {loc[CONF_LOCATION_MODE]}"
+    zone = loc.get(CONF_LOCATION_ZONE, "")
+    if zone:
+        display += f", {zone}"
+    return display + ")"
 
 
 def _location_list_str(hass: HomeAssistant, locations: list[dict[str, Any]]) -> str:
@@ -88,7 +91,11 @@ def _location_select_options(
         state = hass.states.get(entity_id)
         name = state.name if state else entity_id
         loc_type = "static" if loc[CONF_LOCATION_TYPE] == LOCATION_TYPE_STATIC else "tracked"
-        label = f"{name} ({loc_type}, {loc[CONF_LOCATION_MODE]})"
+        label = f"{name} ({loc_type}, {loc[CONF_LOCATION_MODE]}"
+        zone = loc.get(CONF_LOCATION_ZONE, "")
+        if zone:
+            label += f", {zone}"
+        label += ")"
         options.append(SelectOptionDict(value=str(i), label=label))
     return options
 
@@ -234,23 +241,10 @@ class WXWatcherFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         """Handle the initial user step."""
-        if user_input is not None:
-            self._data[CONF_NAME] = user_input[CONF_NAME]
-            self._data[CONF_INTERVAL] = user_input.get(CONF_INTERVAL, DEFAULT_INTERVAL)
-            self._data[CONF_TIMEOUT] = user_input.get(CONF_TIMEOUT, DEFAULT_TIMEOUT)
-            return await self.async_step_locations()
-
-        return self.async_show_form(
-            step_id="user",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(CONF_NAME, default=DEFAULT_NAME): str,
-                    vol.Optional(CONF_INTERVAL, default=DEFAULT_INTERVAL): int,
-                    vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): int,
-                }
-            ),
-            errors=self._errors,
-        )
+        self._data["name"] = DEFAULT_NAME
+        self._data[CONF_INTERVAL] = DEFAULT_INTERVAL
+        self._data[CONF_TIMEOUT] = DEFAULT_TIMEOUT
+        return await self.async_step_locations()
 
     async def async_step_locations(
         self, user_input: dict[str, Any] | None = None
@@ -448,7 +442,7 @@ class WXWatcherFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     def _create_entry(self) -> ConfigFlowResult:
         """Create the config entry from collected data."""
         self._data[CONF_LOCATIONS] = self._locations
-        return self.async_create_entry(title=self._data[CONF_NAME], data=self._data)
+        return self.async_create_entry(title=DEFAULT_NAME, data=self._data)
 
     @staticmethod
     @callback

--- a/custom_components/wx_watcher/const.py
+++ b/custom_components/wx_watcher/const.py
@@ -32,20 +32,28 @@ LOCATION_MODE_POINT = "point"
 
 DEFAULT_ICON = "mdi:alert"
 DEFAULT_NAME = "WX Watcher"
-DEFAULT_INTERVAL = 1
-DEFAULT_TIMEOUT = 120
+DEFAULT_INTERVAL = 60
+DEFAULT_TIMEOUT = 60
+
+MIN_INTERVAL = 15
+MAX_INTERVAL = 300
+INTERVAL_STEP = 15
+
+MIN_TIMEOUT = 5
+MAX_TIMEOUT = 120
+TIMEOUT_STEP = 5
 
 EVENT_ATTR_CONFIG_ENTRY_ID = "config_entry_id"
 EVENT_ATTR_SOURCES = "sources"
 
-VERSION = "8.0.0"
+VERSION = "8.1.1"
 ISSUE_URL = "https://github.com/nalabelle/wx_watcher"
 DOMAIN = "wx_watcher"
 PLATFORM = "sensor"
 ATTRIBUTION = "Data provided by Weather.gov"
 COORDINATOR = "coordinator"
-PLATFORMS = [Platform.SENSOR]
-CONFIG_VERSION = 4
+PLATFORMS = [Platform.SENSOR, Platform.NUMBER]
+CONFIG_VERSION = 5
 
 EVENT_ALERT_CREATED = f"{DOMAIN}_alert_created"
 EVENT_ALERT_UPDATED = f"{DOMAIN}_alert_updated"

--- a/custom_components/wx_watcher/coordinator.py
+++ b/custom_components/wx_watcher/coordinator.py
@@ -3,8 +3,8 @@
 # Derived in part from nws_alerts by finity69x2
 # (https://github.com/finity69x2/nws_alerts).
 # DataUpdateCoordinator structure, _async_update_data pattern with
-# async_timeout + UpdateFailed, _get_tracker_gps originate from the
-# upstream coordinator. See NOTICE for details.
+# async_timeout + UpdateFailed originate from the upstream coordinator.
+# See NOTICE for details.
 # As upstream-derived code is rewritten or removed, this comment should
 # be updated or removed accordingly.
 
@@ -31,14 +31,30 @@ from .const import (
     CONF_LOCATION_ZONE,
     CONF_LOCATIONS,
     CONF_TIMEOUT,
+    DEFAULT_INTERVAL,
+    DEFAULT_NAME,
+    DEFAULT_TIMEOUT,
     LOCATION_MODE_POINT,
     LOCATION_MODE_ZONE,
     LOCATION_TYPE_STATIC,
     LOCATION_TYPE_TRACKED,
+    MAX_TIMEOUT,
+    MIN_TIMEOUT,
 )
 from .events import async_fire_alert_events, async_fire_stale_data_event
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _parse_timestamp(ts: str) -> datetime | None:
+    """Parse ISO 8601 timestamp, return None if invalid."""
+    if not ts:
+        return None
+    try:
+        return datetime.fromisoformat(ts)
+    except ValueError:
+        _LOGGER.warning("Invalid timestamp from NWS API: %s", ts)
+        return None
 
 
 def _parse_gps_str(gps_str: str) -> tuple[float, float]:
@@ -90,8 +106,8 @@ class AlertsDataUpdateCoordinator(DataUpdateCoordinator):
         user_agent: str,
     ) -> None:
         """Initialize the coordinator."""
-        self._interval = timedelta(minutes=config.data.get(CONF_INTERVAL, 1))
-        self._timeout = config.data.get(CONF_TIMEOUT, 120)
+        self._interval = timedelta(seconds=config.data.get(CONF_INTERVAL, DEFAULT_INTERVAL))
+        self._timeout = config.data.get(CONF_TIMEOUT, DEFAULT_TIMEOUT)
         self._config = config
         self._session = session
         self._user_agent = user_agent
@@ -100,6 +116,8 @@ class AlertsDataUpdateCoordinator(DataUpdateCoordinator):
         self._previous_merged: dict[str, dict] = {}
         self._previous_per_location: dict[str, set[str]] = {}
         self._last_successful_update: str | None = None
+        self._nws_updated: str | None = None
+        self._tracker_gps_warned: dict[str, datetime] = {}
 
         _LOGGER.debug("Data will be updated every %s", self._interval)
 
@@ -107,7 +125,7 @@ class AlertsDataUpdateCoordinator(DataUpdateCoordinator):
             hass,
             _LOGGER,
             config_entry=config,
-            name=config.data.get("name", "NWS Alerts"),
+            name=DEFAULT_NAME,
             update_interval=self._interval,
         )
 
@@ -115,6 +133,21 @@ class AlertsDataUpdateCoordinator(DataUpdateCoordinator):
     def entry_id(self) -> str:
         """Return the config entry ID."""
         return self._entry_id
+
+    @property
+    def timeout(self) -> int:
+        """Return the current timeout in seconds."""
+        return self._timeout
+
+    @timeout.setter
+    def timeout(self, value: int) -> None:
+        """Set the timeout in seconds."""
+        self._timeout = max(MIN_TIMEOUT, min(MAX_TIMEOUT, value))
+
+    @property
+    def nws_updated(self) -> str | None:
+        """Return the NWS API 'updated' timestamp from last fetch."""
+        return self._nws_updated
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data from all locations and merge."""
@@ -146,12 +179,21 @@ class AlertsDataUpdateCoordinator(DataUpdateCoordinator):
             all_zone_ids.update(loc_zones)
 
         zone_alerts_raw: list[dict[str, Any]] = []
+        nws_updated: str | None = None
         if all_zone_ids:
-            zone_alerts_raw = await fetch_zone_alerts(
+            zone_alerts_raw, zone_updated = await fetch_zone_alerts(
                 self._session, self._user_agent, sorted(all_zone_ids)
             )
+            if zone_updated:
+                nws_updated = zone_updated
 
-        point_results = await self._fetch_point_alerts(point_tasks)
+        point_results, point_updated = await self._fetch_point_alerts(point_tasks)
+        point_dt = _parse_timestamp(point_updated)
+        zone_dt = _parse_timestamp(nws_updated or "")
+        if point_dt and (zone_dt is None or point_dt > zone_dt):
+            nws_updated = point_updated
+
+        self._nws_updated = nws_updated
 
         merged = self._merge_zone_alerts(zone_alerts_raw, location_zones)
         self._merge_point_alerts(point_results, merged)
@@ -225,10 +267,13 @@ class AlertsDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def _fetch_point_alerts(
         self, point_tasks: list[tuple[dict, tuple[float, float]]]
-    ) -> dict[str, list[dict[str, Any]]]:
-        """Fetch point alerts for all point-mode locations concurrently."""
+    ) -> tuple[dict[str, list[dict[str, Any]]], str]:
+        """Fetch point alerts for all point-mode locations concurrently.
+
+        Returns (results dict, latest updated timestamp).
+        """
         if not point_tasks:
-            return {}
+            return {}, ""
 
         coros = [
             fetch_point_alerts(self._session, self._user_agent, coords[0], coords[1])
@@ -236,6 +281,8 @@ class AlertsDataUpdateCoordinator(DataUpdateCoordinator):
         ]
         raw_results = await asyncio.gather(*coros, return_exceptions=True)
         results: dict[str, list[dict[str, Any]]] = {}
+        latest_updated = ""
+        latest_dt: datetime | None = None
         for i, result in enumerate(raw_results):
             loc = point_tasks[i][0]
             eid = _entity_id(loc)
@@ -246,8 +293,13 @@ class AlertsDataUpdateCoordinator(DataUpdateCoordinator):
                     result,
                 )
             else:
-                results[eid] = cast(list[dict[str, Any]], result)
-        return results
+                features, updated = cast(tuple[list[dict[str, Any]], str], result)
+                results[eid] = features
+                updated_dt = _parse_timestamp(updated)
+                if updated_dt and (latest_dt is None or updated_dt > latest_dt):
+                    latest_updated = updated
+                    latest_dt = updated_dt
+        return results, latest_updated
 
     def _merge_zone_alerts(
         self,
@@ -304,8 +356,15 @@ class AlertsDataUpdateCoordinator(DataUpdateCoordinator):
             return None
         attrs = entity.attributes
         if "latitude" in attrs and "longitude" in attrs:
+            self._tracker_gps_warned.pop(tracker_entity_id, None)
             return f"{attrs['latitude']},{attrs['longitude']}"
-        _LOGGER.warning("Tracker %s missing latitude/longitude attributes", tracker_entity_id)
+        now = datetime.now(tz=UTC)
+        last_warned = self._tracker_gps_warned.get(tracker_entity_id)
+        if last_warned is None or (now - last_warned) > timedelta(hours=24):
+            _LOGGER.warning("Tracker %s missing latitude/longitude attributes", tracker_entity_id)
+            self._tracker_gps_warned[tracker_entity_id] = now
+        else:
+            _LOGGER.debug("Tracker %s missing latitude/longitude attributes", tracker_entity_id)
         return None
 
     def _display_name(self, entity_id: str) -> str:

--- a/custom_components/wx_watcher/manifest.json
+++ b/custom_components/wx_watcher/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/nalabelle/wx_watcher/issues",
   "requirements": [],
-  "version": "7.0.1"
+  "version": "8.1.1"
 }

--- a/custom_components/wx_watcher/migration.py
+++ b/custom_components/wx_watcher/migration.py
@@ -1,0 +1,49 @@
+"""Config entry migration for WX Watcher."""
+
+import logging
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import CONF_INTERVAL, CONF_TIMEOUT, CONFIG_VERSION, DEFAULT_TIMEOUT, MAX_TIMEOUT
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    """Migrate old config entry data to current version."""
+    version = config_entry.version
+    data = {**config_entry.data}
+
+    if version == 1:
+        _LOGGER.debug("Migrating config entry from version 1")
+        version = 2
+
+    if version == 2:
+        _LOGGER.debug("Migrating config entry from version 2")
+        version = 3
+
+    if version == 3:
+        _LOGGER.debug("Migrating config entry from version 3")
+        version = 4
+
+    if version == 4:
+        _LOGGER.debug("Migrating config entry from version 4 to 5")
+        interval = data.get(CONF_INTERVAL, 1)
+        data[CONF_INTERVAL] = interval * 60
+
+        timeout = data.get(CONF_TIMEOUT, 120)
+        if timeout > MAX_TIMEOUT:
+            data[CONF_TIMEOUT] = MAX_TIMEOUT
+        elif timeout == 120:
+            data[CONF_TIMEOUT] = DEFAULT_TIMEOUT
+
+        version = 5
+
+    if version != CONFIG_VERSION:
+        _LOGGER.error("Cannot migrate config entry from unknown version %s", version)
+        return False
+
+    hass.config_entries.async_update_entry(config_entry, data=data, version=version)
+    _LOGGER.info("Migration to version %s complete", version)
+    return True

--- a/custom_components/wx_watcher/number.py
+++ b/custom_components/wx_watcher/number.py
@@ -1,0 +1,150 @@
+"""WX Watcher number entities."""
+
+from datetime import timedelta
+
+from homeassistant.components.number import RestoreNumber
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import (
+    CONF_INTERVAL,
+    CONF_TIMEOUT,
+    COORDINATOR,
+    DEFAULT_INTERVAL,
+    DEFAULT_NAME,
+    DEFAULT_TIMEOUT,
+    DOMAIN,
+    INTERVAL_STEP,
+    MAX_INTERVAL,
+    MAX_TIMEOUT,
+    MIN_INTERVAL,
+    MIN_TIMEOUT,
+    TIMEOUT_STEP,
+)
+from .coordinator import AlertsDataUpdateCoordinator
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the WX Watcher number platform."""
+    coordinator = hass.data[DOMAIN][entry.entry_id][COORDINATOR]
+    async_add_entities(
+        [
+            WXWatcherIntervalNumber(coordinator, entry),
+            WXWatcherTimeoutNumber(coordinator, entry),
+        ],
+        True,
+    )
+
+
+class WXWatcherIntervalNumber(CoordinatorEntity, RestoreNumber):
+    """Number entity for update interval control."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Update Interval"
+    _attr_native_min_value = MIN_INTERVAL
+    _attr_native_max_value = MAX_INTERVAL
+    _attr_native_step = INTERVAL_STEP
+    _attr_native_unit_of_measurement = "s"
+    _attr_icon = "mdi:timer-outline"
+    _attr_entity_category = EntityCategory.CONFIG
+    coordinator: AlertsDataUpdateCoordinator
+
+    def __init__(self, coordinator: AlertsDataUpdateCoordinator, entry: ConfigEntry) -> None:
+        """Initialize the number entity."""
+        super().__init__(coordinator)
+        self._config_entry = entry
+        self._attr_native_value = float(entry.data.get(CONF_INTERVAL, DEFAULT_INTERVAL))
+        self._attr_unique_id = f"{entry.entry_id}_update_interval"
+        self._attr_device_info = DeviceInfo(
+            entry_type=DeviceEntryType.SERVICE,
+            identifiers={(DOMAIN, entry.entry_id)},
+            manufacturer="NWS",
+            name=DEFAULT_NAME,
+        )
+
+    @property
+    def native_value(self) -> float | None:
+        """Return current interval value."""
+        return self._attr_native_value
+
+    async def async_added_to_hass(self) -> None:
+        """Restore last value on startup."""
+        await super().async_added_to_hass()
+        if (
+            last := await self.async_get_last_number_data()
+        ) is not None and last.native_value is not None:
+            self._attr_native_value = last.native_value
+            self.coordinator.update_interval = timedelta(seconds=int(last.native_value))
+        else:
+            self.coordinator.update_interval = timedelta(
+                seconds=int(self._attr_native_value or DEFAULT_INTERVAL)
+            )
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Change the update interval."""
+        int_value = int(value)
+        int_value = max(MIN_INTERVAL, min(MAX_INTERVAL, int_value))
+        self._attr_native_value = float(int_value)
+        self.coordinator.update_interval = timedelta(seconds=int_value)
+        await self.coordinator.async_request_refresh()
+        self.async_write_ha_state()
+
+
+class WXWatcherTimeoutNumber(CoordinatorEntity, RestoreNumber):
+    """Number entity for update timeout control."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Update Timeout"
+    _attr_native_min_value = MIN_TIMEOUT
+    _attr_native_max_value = MAX_TIMEOUT
+    _attr_native_step = TIMEOUT_STEP
+    _attr_native_unit_of_measurement = "s"
+    _attr_icon = "mdi:timer-off-outline"
+    _attr_entity_category = EntityCategory.CONFIG
+    coordinator: AlertsDataUpdateCoordinator
+
+    def __init__(self, coordinator: AlertsDataUpdateCoordinator, entry: ConfigEntry) -> None:
+        """Initialize the number entity."""
+        super().__init__(coordinator)
+        self._config_entry = entry
+        self._attr_native_value = float(entry.data.get(CONF_TIMEOUT, DEFAULT_TIMEOUT))
+        self._attr_unique_id = f"{entry.entry_id}_update_timeout"
+        self._attr_device_info = DeviceInfo(
+            entry_type=DeviceEntryType.SERVICE,
+            identifiers={(DOMAIN, entry.entry_id)},
+            manufacturer="NWS",
+            name=DEFAULT_NAME,
+        )
+
+    @property
+    def native_value(self) -> float | None:
+        """Return current timeout value."""
+        return self._attr_native_value
+
+    async def async_added_to_hass(self) -> None:
+        """Restore last value on startup."""
+        await super().async_added_to_hass()
+        if (
+            last := await self.async_get_last_number_data()
+        ) is not None and last.native_value is not None:
+            self._attr_native_value = last.native_value
+            self.coordinator.timeout = int(last.native_value)
+        else:
+            self.coordinator.timeout = int(self._attr_native_value or DEFAULT_TIMEOUT)
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Change the update timeout."""
+        int_value = int(value)
+        int_value = max(MIN_TIMEOUT, min(MAX_TIMEOUT, int_value))
+        self._attr_native_value = float(int_value)
+        self.coordinator.timeout = int_value
+        await self.coordinator.async_request_refresh()
+        self.async_write_ha_state()

--- a/custom_components/wx_watcher/sensor.py
+++ b/custom_components/wx_watcher/sensor.py
@@ -13,12 +13,13 @@ from typing import Final
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntityDescription
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_ATTRIBUTION, CONF_NAME
+from homeassistant.const import ATTR_ATTRIBUTION
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import ATTRIBUTION, CONF_LOCATIONS, COORDINATOR, DOMAIN
+from .const import ATTRIBUTION, CONF_LOCATIONS, COORDINATOR, DEFAULT_NAME, DOMAIN
+from .coordinator import AlertsDataUpdateCoordinator
 
 SENSOR_TYPES: Final[dict[str, SensorEntityDescription]] = {
     "state": SensorEntityDescription(key="state", name="Alerts", icon="mdi:alert"),
@@ -42,6 +43,8 @@ async def async_setup_entry(hass, entry, async_add_entities):
 class WXWatcherSensor(CoordinatorEntity):
     """Representation of a Sensor."""
 
+    coordinator: AlertsDataUpdateCoordinator
+
     def __init__(
         self,
         hass: HomeAssistant,
@@ -55,7 +58,7 @@ class WXWatcherSensor(CoordinatorEntity):
         self._hass = hass
 
         self._attr_icon = sensor_description.icon
-        self._attr_name = f"{entry.data.get(CONF_NAME, DOMAIN)} {sensor_description.name}"
+        self._attr_name = f"{DEFAULT_NAME} {sensor_description.name}"
         self._attr_device_class = sensor_description.device_class
         self._attr_unique_id = f"{self._attr_name}_{entry.entry_id}"
 
@@ -76,6 +79,8 @@ class WXWatcherSensor(CoordinatorEntity):
             return attrs
         if "alerts" in self.coordinator.data and self._key == "state":
             attrs["Alerts"] = self.coordinator.data["alerts"]
+            if self.coordinator.nws_updated:
+                attrs["nws_updated"] = self.coordinator.nws_updated
 
         locations = self._config.data.get(CONF_LOCATIONS, [])
         if locations:
@@ -89,6 +94,8 @@ class WXWatcherSensor(CoordinatorEntity):
                         "name": state.name if state else entity_id,
                         "type": loc.get("type", ""),
                         "mode": loc.get("mode", ""),
+                        "zone": loc.get("zone", ""),
+                        "gps": loc.get("gps", ""),
                     }
                 )
 
@@ -102,5 +109,5 @@ class WXWatcherSensor(CoordinatorEntity):
             entry_type=DeviceEntryType.SERVICE,
             identifiers={(DOMAIN, self._config.entry_id)},
             manufacturer="NWS",
-            name=self._config.data.get(CONF_NAME, "WX Watcher"),
+            name=DEFAULT_NAME,
         )

--- a/custom_components/wx_watcher/strings.json
+++ b/custom_components/wx_watcher/strings.json
@@ -1,15 +1,6 @@
 {
   "config": {
     "step": {
-      "user": {
-        "title": "WX Watcher",
-        "description": "Set up WX Watcher. You can monitor one or more locations (home, work, phone, etc.), each with its own mode.",
-        "data": {
-          "name": "Name",
-          "interval": "Update interval (minutes)",
-          "timeout": "Update timeout (seconds)"
-        }
-      },
       "locations": {
         "title": "Locations",
         "description": "Current locations: {location_list}\n\nAdd, edit, or remove a location, or finish setup.",

--- a/custom_components/wx_watcher/translations/en.json
+++ b/custom_components/wx_watcher/translations/en.json
@@ -1,15 +1,6 @@
 {
   "config": {
     "step": {
-      "user": {
-        "title": "WX Watcher",
-        "description": "Set up WX Watcher. You can monitor one or more locations (home, work, phone, etc.), each with its own mode.",
-        "data": {
-          "name": "Name",
-          "interval": "Update interval (minutes)",
-          "timeout": "Update timeout (seconds)"
-        }
-      },
       "locations": {
         "title": "Locations",
         "description": "Current locations: {location_list}\n\nAdd, edit, or remove a location, or finish setup.",

--- a/tests/const.py
+++ b/tests/const.py
@@ -15,8 +15,8 @@ from custom_components.wx_watcher.const import (
 
 CONFIG_DATA = {
     "name": "WX Watcher",
-    "interval": 1,
-    "timeout": 120,
+    "interval": 60,
+    "timeout": 60,
     "locations": [
         {
             CONF_LOCATION_TYPE: LOCATION_TYPE_STATIC,
@@ -30,8 +30,8 @@ CONFIG_DATA = {
 
 CONFIG_DATA_TWO_LOCATIONS = {
     "name": "WX Watcher",
-    "interval": 1,
-    "timeout": 120,
+    "interval": 60,
+    "timeout": 60,
     "locations": [
         {
             CONF_LOCATION_TYPE: LOCATION_TYPE_STATIC,
@@ -52,8 +52,8 @@ CONFIG_DATA_TWO_LOCATIONS = {
 
 CONFIG_DATA_POINT_ONLY = {
     "name": "WX Watcher",
-    "interval": 1,
-    "timeout": 120,
+    "interval": 60,
+    "timeout": 60,
     "locations": [
         {
             CONF_LOCATION_TYPE: LOCATION_TYPE_STATIC,
@@ -67,8 +67,8 @@ CONFIG_DATA_POINT_ONLY = {
 
 CONFIG_DATA_TRACKER_IN_STATIC_ZONE = {
     "name": "WX Watcher",
-    "interval": 1,
-    "timeout": 120,
+    "interval": 60,
+    "timeout": 60,
     "locations": [
         {
             CONF_LOCATION_TYPE: LOCATION_TYPE_STATIC,

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -18,15 +18,9 @@ async def test_form_static_zone(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
-        assert result["type"] == FlowResultType.FORM
-
-        user_data = {
-            "name": "Testing Alerts",
-            "interval": 1,
-            "timeout": 120,
-        }
-        result = await hass.config_entries.flow.async_configure(result["flow_id"], user_data)
         await hass.async_block_till_done()
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "locations"
 
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], {"action": "add_static"}
@@ -49,7 +43,7 @@ async def test_form_static_zone(hass):
             result["flow_id"], {"action": "done"}
         )
         assert result["type"] == FlowResultType.CREATE_ENTRY
-        assert result["title"] == "Testing Alerts"
+        assert result["title"] == "WX Watcher"
         assert len(result["data"]["locations"]) == 1
         assert result["data"]["locations"][0]["ha_zone"] == "zone.home"
         assert result["data"]["locations"][0]["zone"] == "AZC013,AZZ540"
@@ -64,9 +58,8 @@ async def test_form_static_zone_with_manual_edit(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
-        user_data = {"name": "Testing", "interval": 1, "timeout": 120}
-        result = await hass.config_entries.flow.async_configure(result["flow_id"], user_data)
         await hass.async_block_till_done()
+        assert result["step_id"] == "locations"
 
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], {"action": "add_static"}
@@ -94,9 +87,8 @@ async def test_form_static_point_mode(hass):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
-        user_data = {"name": "Testing", "interval": 1, "timeout": 120}
-        result = await hass.config_entries.flow.async_configure(result["flow_id"], user_data)
         await hass.async_block_till_done()
+        assert result["step_id"] == "locations"
 
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], {"action": "add_static"}

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -1,0 +1,94 @@
+"""Tests for config entry migration."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.wx_watcher.const import (
+    CONF_INTERVAL,
+    CONF_TIMEOUT,
+    CONFIG_VERSION,
+    DEFAULT_TIMEOUT,
+    MAX_TIMEOUT,
+)
+from custom_components.wx_watcher.migration import async_migrate_entry
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def mock_update_entry(hass):
+    """Mock async_update_entry and restore after test."""
+    original = hass.config_entries.async_update_entry
+
+    def _update(config_entry, **kwargs):
+        if "data" in kwargs:
+            config_entry.data = kwargs["data"]
+        if "version" in kwargs:
+            config_entry.version = kwargs["version"]
+
+    hass.config_entries.async_update_entry = _update
+    yield
+    hass.config_entries.async_update_entry = original
+
+
+def _make_entry(hass, version: int, data: dict):
+    """Create a mock config entry."""
+    entry = MagicMock()
+    entry.version = version
+    entry.data = dict(data)
+    return entry
+
+
+async def test_migration_v4_to_v5_default_values(hass, mock_update_entry):
+    """Test v4→v5 migration with old defaults (interval=1min, timeout=120s)."""
+    entry = _make_entry(hass, version=4, data={CONF_INTERVAL: 1, CONF_TIMEOUT: 120})
+    result = await async_migrate_entry(hass, entry)
+    assert result is True
+    assert entry.version == CONFIG_VERSION
+    assert entry.data[CONF_INTERVAL] == 60
+    assert entry.data[CONF_TIMEOUT] == DEFAULT_TIMEOUT
+
+
+async def test_migration_v4_to_v5_custom_interval(hass, mock_update_entry):
+    """Test v4→v5 migration with custom interval (2 minutes)."""
+    entry = _make_entry(hass, version=4, data={CONF_INTERVAL: 2, CONF_TIMEOUT: 120})
+    result = await async_migrate_entry(hass, entry)
+    assert result is True
+    assert entry.data[CONF_INTERVAL] == 120
+    assert entry.data[CONF_TIMEOUT] == DEFAULT_TIMEOUT
+
+
+async def test_migration_v4_to_v5_custom_timeout(hass, mock_update_entry):
+    """Test v4→v5 migration with custom timeout — preserved if within bounds."""
+    entry = _make_entry(hass, version=4, data={CONF_INTERVAL: 1, CONF_TIMEOUT: 60})
+    result = await async_migrate_entry(hass, entry)
+    assert result is True
+    assert entry.data[CONF_INTERVAL] == 60
+    assert entry.data[CONF_TIMEOUT] == 60
+
+
+async def test_migration_v4_to_v5_timeout_over_max(hass, mock_update_entry):
+    """Test v4→v5 migration caps timeout exceeding MAX_TIMEOUT."""
+    entry = _make_entry(hass, version=4, data={CONF_INTERVAL: 1, CONF_TIMEOUT: 200})
+    result = await async_migrate_entry(hass, entry)
+    assert result is True
+    assert entry.data[CONF_TIMEOUT] == MAX_TIMEOUT
+
+
+async def test_migration_v4_to_v5_missing_timeout(hass, mock_update_entry):
+    """Test v4→v5 migration when timeout key is missing (defaults to 120→DEFAULT_TIMEOUT)."""
+    entry = _make_entry(hass, version=4, data={CONF_INTERVAL: 3})
+    result = await async_migrate_entry(hass, entry)
+    assert result is True
+    assert entry.data[CONF_INTERVAL] == 180
+    assert entry.data[CONF_TIMEOUT] == DEFAULT_TIMEOUT
+
+
+async def test_migration_v4_to_v5_missing_interval(hass, mock_update_entry):
+    """Test v4→v5 migration when interval key is missing (defaults to 1min→60s)."""
+    entry = _make_entry(hass, version=4, data={CONF_TIMEOUT: 120})
+    result = await async_migrate_entry(hass, entry)
+    assert result is True
+    assert entry.data[CONF_INTERVAL] == 60
+    assert entry.data[CONF_TIMEOUT] == DEFAULT_TIMEOUT

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -1,0 +1,109 @@
+"""Tests for number entity bounds validation."""
+
+from datetime import timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.wx_watcher.const import (
+    CONF_INTERVAL,
+    CONF_TIMEOUT,
+    DEFAULT_INTERVAL,
+    DEFAULT_TIMEOUT,
+    MAX_INTERVAL,
+    MAX_TIMEOUT,
+    MIN_INTERVAL,
+    MIN_TIMEOUT,
+)
+from custom_components.wx_watcher.number import WXWatcherIntervalNumber, WXWatcherTimeoutNumber
+
+pytestmark = pytest.mark.asyncio
+
+
+def _make_coordinator():
+    """Create a mock coordinator."""
+    coordinator = MagicMock()
+    coordinator.update_interval = timedelta(seconds=DEFAULT_INTERVAL)
+    coordinator.timeout = DEFAULT_TIMEOUT
+    coordinator.async_request_refresh = AsyncMock()
+    return coordinator
+
+
+def _make_entry(data: dict | None = None):
+    """Create a mock config entry."""
+    entry = MagicMock()
+    entry.entry_id = "test_entry_id"
+    entry.data = data or {CONF_INTERVAL: DEFAULT_INTERVAL, CONF_TIMEOUT: DEFAULT_TIMEOUT}
+    return entry
+
+
+async def test_interval_clamps_below_min():
+    """Setting interval below MIN_INTERVAL should clamp to MIN_INTERVAL."""
+    coordinator = _make_coordinator()
+    entry = _make_entry()
+    entity = WXWatcherIntervalNumber(coordinator, entry)
+    entity.hass = MagicMock()
+
+    with patch.object(entity, "async_write_ha_state"):
+        await entity.async_set_native_value(float(MIN_INTERVAL - 10))
+    assert entity.native_value == float(MIN_INTERVAL)
+
+
+async def test_interval_clamps_above_max():
+    """Setting interval above MAX_INTERVAL should clamp to MAX_INTERVAL."""
+    coordinator = _make_coordinator()
+    entry = _make_entry()
+    entity = WXWatcherIntervalNumber(coordinator, entry)
+    entity.hass = MagicMock()
+
+    with patch.object(entity, "async_write_ha_state"):
+        await entity.async_set_native_value(float(MAX_INTERVAL + 100))
+    assert entity.native_value == float(MAX_INTERVAL)
+
+
+async def test_interval_within_bounds_unchanged():
+    """Setting interval within bounds should not clamp."""
+    coordinator = _make_coordinator()
+    entry = _make_entry()
+    entity = WXWatcherIntervalNumber(coordinator, entry)
+    entity.hass = MagicMock()
+
+    with patch.object(entity, "async_write_ha_state"):
+        await entity.async_set_native_value(60.0)
+    assert entity.native_value == 60.0
+
+
+async def test_timeout_clamps_below_min():
+    """Setting timeout below MIN_TIMEOUT should clamp to MIN_TIMEOUT."""
+    coordinator = _make_coordinator()
+    entry = _make_entry()
+    entity = WXWatcherTimeoutNumber(coordinator, entry)
+    entity.hass = MagicMock()
+
+    with patch.object(entity, "async_write_ha_state"):
+        await entity.async_set_native_value(float(MIN_TIMEOUT - 5))
+    assert entity.native_value == float(MIN_TIMEOUT)
+
+
+async def test_timeout_clamps_above_max():
+    """Setting timeout above MAX_TIMEOUT should clamp to MAX_TIMEOUT."""
+    coordinator = _make_coordinator()
+    entry = _make_entry()
+    entity = WXWatcherTimeoutNumber(coordinator, entry)
+    entity.hass = MagicMock()
+
+    with patch.object(entity, "async_write_ha_state"):
+        await entity.async_set_native_value(float(MAX_TIMEOUT + 50))
+    assert entity.native_value == float(MAX_TIMEOUT)
+
+
+async def test_timeout_within_bounds_unchanged():
+    """Setting timeout within bounds should not clamp."""
+    coordinator = _make_coordinator()
+    entry = _make_entry()
+    entity = WXWatcherTimeoutNumber(coordinator, entry)
+    entity.hass = MagicMock()
+
+    with patch.object(entity, "async_write_ha_state"):
+        await entity.async_set_native_value(45.0)
+    assert entity.native_value == 45.0

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -17,7 +17,7 @@ async def test_sensor(hass, mock_api):
         domain=DOMAIN,
         title="WX Watcher",
         data=CONFIG_DATA,
-        version=4,
+        version=5,
     )
 
     entry.add_to_hass(hass)
@@ -40,6 +40,8 @@ async def test_sensor(hass, mock_api):
     assert loc_info[0]["name"] == "Home"
     assert loc_info[0]["type"] == "static"
     assert loc_info[0]["mode"] == "zone"
+    assert loc_info[0]["zone"] == "AZZ540,AZC013"
+    assert loc_info[0]["gps"] == "33.25,-112.30"
 
     entity_registry = er.async_get(hass)
     assert entity_registry.async_get(alerts_entity_id)


### PR DESCRIPTION
## Summary

- Add WXWatcherIntervalNumber and WXWatcherTimeoutNumber entities with bounds clamping and RestoreNumber persistence
- Remove name form from config flow; use fixed "WX Watcher" instance name
- Show zone IDs in config flow location options for readability
- Add config entry migration v4→v5: interval minutes→seconds, timeout validation (default 120→60, cap at MAX_TIMEOUT)
- Increase DEFAULT_TIMEOUT from 30s to 60s
- Add bounds validation in coordinator timeout setter
- Capture NWS API "updated" timestamp, expose as nws_updated sensor attribute
- Use datetime parsing for robust timestamp comparison instead of strings
- Tracker GPS warning re-emits every 24h instead of permanent suppression
- Add 12 tests: 6 migration, 6 number entity bounds validation
- Convert test helper to proper pytest fixture with teardown
- Update NOTICE: remove stale default-values/attributions, remove _get_tracker_gps attribution (implementation fully rewritten)
- Bump CONFIG_VERSION=5, VERSION="8.1.1"

Assisted-by: GLM 5.1 via OpenCode