### PR TITLE
perf: eliminate per-minute recorder writes, add structured fetch events

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ A Home Assistant custom integration for monitoring weather alerts from the US Na
 - **Tracker skip optimization** — tracked devices inside a static location's HA zone are skipped (zone query is a superset)
 - **Deduplicated alerts** — same alert observed from multiple locations fires one event, with a `sources` list showing which locations detected it
 - **Combined zone queries** — all zone-mode locations are queried in a single API call, minimizing NWS API usage
-- **Event-driven architecture** — fires `wx_watcher_alert_created`, `wx_watcher_alert_updated`, `wx_watcher_alert_cleared`, and `wx_watcher_alert_stale_data` events for precise automation triggers
-- **Dashboard sensor** — `sensor.wx_watcher_alerts` shows current alert count with full details in attributes; `sensor.wx_watcher_last_updated` shows the last successful update time
+- **Event-driven architecture** — fires `wx_watcher_alert_created`, `wx_watcher_alert_updated`, `wx_watcher_alert_cleared`, and `wx_watcher_alert_fetch_result` events for precise automation triggers
+- **Recorder-efficient** — sensor state only updates when alert data actually changes, minimizing database writes
+- **Dashboard sensor** — `sensor.wx_watcher_alerts` shows current alert count with full alert details and `nws_updated` timestamp in attributes
 
 ## Installation
 
@@ -56,16 +57,16 @@ Go to **Settings → Devices & Services → Add Integration** and search for "WX
 
 Events are fired for each unique alert (deduplicated across locations):
 
-| Event                         | When                          |
-| ----------------------------- | ----------------------------- |
-| `wx_watcher_alert_created`    | New alert appears             |
-| `wx_watcher_alert_updated`    | Existing alert's data changes |
-| `wx_watcher_alert_cleared`    | Alert is no longer active     |
-| `wx_watcher_alert_stale_data` | NWS API fetch failed          |
+| Event                           | When                                   |
+| ------------------------------- | -------------------------------------- |
+| `wx_watcher_alert_created`      | New alert appears                      |
+| `wx_watcher_alert_updated`      | Existing alert's data changes          |
+| `wx_watcher_alert_cleared`      | Alert is no longer active              |
+| `wx_watcher_alert_fetch_result` | Every fetch cycle (success or failure) |
 
-### Event Data
+### Alert Event Data
 
-Each event carries these fields:
+Each alert event (`created`, `updated`, `cleared`) carries these fields:
 
 | Field                                           | Description                                                                                                                                                     |
 | ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -90,6 +91,16 @@ Each event carries these fields:
 | `SenderName`                                    | Issuing NWS office                                                                                                                                              |
 | `config_entry_id`                               | Config entry that fired the event                                                                                                                               |
 | `sources`                                       | List of source dicts. Static: `{"ha_zone": "zone.home", "mode": "zone"}`. Tracked: `{"tracker": "device_tracker.phone", "mode": "point"}`.                      |
+
+### Fetch Result Event Data
+
+The `wx_watcher_alert_fetch_result` event fires on every fetch cycle (success or failure):
+
+| Field             | Description                                                      |
+| ----------------- | ---------------------------------------------------------------- |
+| `status`          | `"ok"`, `"http_error"`, `"timeout"`, or `"error"`                |
+| `http_status`     | HTTP status code (e.g., 503, 500). Only present on `http_error`. |
+| `last_successful` | ISO 8601 timestamp of last successful fetch, or `null`           |
 
 ### Automation Example
 
@@ -147,10 +158,30 @@ To update, re-import the blueprint from the same URL.
 
 ## Sensors
 
-| Entity                           | State                            | Attributes                                                                           |
-| -------------------------------- | -------------------------------- | ------------------------------------------------------------------------------------ |
-| `sensor.wx_watcher_alerts`       | Number of active alerts          | `Alerts` (full list with sources), `locations` (configured locations), `attribution` |
-| `sensor.wx_watcher_last_updated` | Last successful update timestamp | `attribution`                                                                        |
+| Entity                     | State                   | Attributes                                                      |
+| -------------------------- | ----------------------- | --------------------------------------------------------------- |
+| `sensor.wx_watcher_alerts` | Number of active alerts | `Alerts` (full list with sources), `nws_updated`, `attribution` |
+
+## Breaking Changes from v8.1
+
+- **`sensor.wx_watcher_last_updated` removed** — the `nws_updated` attribute on `sensor.wx_watcher_alerts` shows when NWS alert data last changed. For "is the integration alive?", use entity availability. For per-fetch status, subscribe to the `wx_watcher_alert_fetch_result` event.
+- **`wx_watcher_alert_stale_data` event replaced by `wx_watcher_alert_fetch_result`** — fires on every fetch cycle (success and failure) with structured status data. Migration:
+
+  ```yaml
+  # Old (v8.1):
+  trigger:
+    - platform: event
+      event_type: wx_watcher_alert_stale_data
+
+  # New (v8.2):
+  trigger:
+    - platform: event
+      event_type: wx_watcher_alert_fetch_result
+      event_data:
+        status: timeout  # or http_error, error
+  ```
+
+- **`locations` attribute removed** from `sensor.wx_watcher_alerts` — location config is visible in the integration's config entry options.
 
 ## Breaking Changes from v7
 

--- a/custom_components/wx_watcher/api.py
+++ b/custom_components/wx_watcher/api.py
@@ -23,6 +23,11 @@ _LOGGER = logging.getLogger(__name__)
 class NWSApiError(Exception):
     """Exception raised when the NWS API returns a non-200 status."""
 
+    def __init__(self, message: str, status: int | None = None) -> None:
+        """Initialize NWSApiError."""
+        super().__init__(message)
+        self.status = status
+
 
 async def resolve_zones(
     session: aiohttp.ClientSession,
@@ -119,7 +124,7 @@ async def _fetch_alerts(
             return features, updated
         msg = f"Problem fetching alerts for {desc}: ({r.status}) {r.reason}"
         _LOGGER.warning(msg)
-        raise NWSApiError(msg)
+        raise NWSApiError(msg, status=r.status)
 
 
 def parse_alert(raw_alert: dict[str, Any]) -> dict[str, Any] | None:

--- a/custom_components/wx_watcher/const.py
+++ b/custom_components/wx_watcher/const.py
@@ -46,7 +46,7 @@ TIMEOUT_STEP = 5
 EVENT_ATTR_CONFIG_ENTRY_ID = "config_entry_id"
 EVENT_ATTR_SOURCES = "sources"
 
-VERSION = "8.1.1"
+VERSION = "8.2.0"
 ISSUE_URL = "https://github.com/nalabelle/wx_watcher"
 DOMAIN = "wx_watcher"
 PLATFORM = "sensor"
@@ -58,4 +58,9 @@ CONFIG_VERSION = 5
 EVENT_ALERT_CREATED = f"{DOMAIN}_alert_created"
 EVENT_ALERT_UPDATED = f"{DOMAIN}_alert_updated"
 EVENT_ALERT_CLEARED = f"{DOMAIN}_alert_cleared"
-EVENT_ALERT_STALE_DATA = f"{DOMAIN}_alert_stale_data"
+EVENT_ALERT_FETCH_RESULT = f"{DOMAIN}_alert_fetch_result"
+
+FETCH_OK = "ok"
+FETCH_HTTP_ERROR = "http_error"
+FETCH_TIMEOUT = "timeout"
+FETCH_ERROR = "error"

--- a/custom_components/wx_watcher/coordinator.py
+++ b/custom_components/wx_watcher/coordinator.py
@@ -20,7 +20,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .api import fetch_point_alerts, fetch_zone_alerts, parse_alert, resolve_zones
+from .api import NWSApiError, fetch_point_alerts, fetch_zone_alerts, parse_alert, resolve_zones
 from .const import (
     CONF_INTERVAL,
     CONF_LOCATION_GPS,
@@ -34,6 +34,10 @@ from .const import (
     DEFAULT_INTERVAL,
     DEFAULT_NAME,
     DEFAULT_TIMEOUT,
+    FETCH_ERROR,
+    FETCH_HTTP_ERROR,
+    FETCH_OK,
+    FETCH_TIMEOUT,
     LOCATION_MODE_POINT,
     LOCATION_MODE_ZONE,
     LOCATION_TYPE_STATIC,
@@ -41,7 +45,7 @@ from .const import (
     MAX_TIMEOUT,
     MIN_TIMEOUT,
 )
-from .events import async_fire_alert_events, async_fire_stale_data_event
+from .events import async_fire_alert_events, async_fire_fetch_result_event
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -127,6 +131,7 @@ class AlertsDataUpdateCoordinator(DataUpdateCoordinator):
             config_entry=config,
             name=DEFAULT_NAME,
             update_interval=self._interval,
+            always_update=False,
         )
 
     @property
@@ -154,14 +159,37 @@ class AlertsDataUpdateCoordinator(DataUpdateCoordinator):
         async with async_timeout(self._timeout):
             try:
                 data = await self._fetch_all_locations()
+            except NWSApiError as error:
+                await async_fire_fetch_result_event(
+                    self.hass,
+                    FETCH_HTTP_ERROR,
+                    last_successful=self._last_successful_update,
+                    http_status=error.status,
+                )
+                raise UpdateFailed(error) from error
+            except TimeoutError as error:
+                await async_fire_fetch_result_event(
+                    self.hass,
+                    FETCH_TIMEOUT,
+                    last_successful=self._last_successful_update,
+                )
+                raise UpdateFailed(error) from error
             except Exception as error:
-                await async_fire_stale_data_event(self.hass, self._last_successful_update)
+                await async_fire_fetch_result_event(
+                    self.hass,
+                    FETCH_ERROR,
+                    last_successful=self._last_successful_update,
+                )
                 raise UpdateFailed(error) from error
 
+            await async_fire_fetch_result_event(
+                self.hass,
+                FETCH_OK,
+                last_successful=self._last_successful_update,
+            )
             await async_fire_alert_events(self.hass, self._entry_id, data, self._previous_merged)
             self._previous_merged = {alert["ID"]: alert for alert in data["alerts"]}
             self._last_successful_update = datetime.now(tz=UTC).isoformat()
-            _LOGGER.debug("Data: %s", data)
             return data
 
     async def _fetch_all_locations(self) -> dict[str, Any]:
@@ -199,11 +227,7 @@ class AlertsDataUpdateCoordinator(DataUpdateCoordinator):
         self._merge_point_alerts(point_results, merged)
 
         alerts = sorted(merged.values(), key=lambda x: x["ID"])
-        return {
-            "state": len(alerts),
-            "alerts": alerts,
-            "last_updated": datetime.now(tz=UTC).isoformat(),
-        }
+        return {"state": len(alerts), "alerts": alerts}
 
     async def _build_fetch_tasks(
         self, static_zone_entity_ids: set[str]

--- a/custom_components/wx_watcher/events.py
+++ b/custom_components/wx_watcher/events.py
@@ -1,13 +1,14 @@
 """Event handling for WX Watcher."""
 
 import logging
+from typing import Any
 
 from homeassistant.core import HomeAssistant
 
 from .const import (
     EVENT_ALERT_CLEARED,
     EVENT_ALERT_CREATED,
-    EVENT_ALERT_STALE_DATA,
+    EVENT_ALERT_FETCH_RESULT,
     EVENT_ALERT_UPDATED,
     EVENT_ATTR_CONFIG_ENTRY_ID,
 )
@@ -76,16 +77,17 @@ def _strip_internal(alert: dict) -> dict:
     return {k: v for k, v in alert.items() if not k.startswith("_")}
 
 
-async def async_fire_stale_data_event(
+async def async_fire_fetch_result_event(
     hass: HomeAssistant,
-    last_successful_update: str | None,
+    status: str,
+    last_successful: str | None,
+    http_status: int | None = None,
 ) -> None:
-    """Fire wx_watcher_alert_stale_data event when an API fetch fails."""
-    _LOGGER.warning(
-        "WX Watcher API fetch failed. Last successful update: %s",
-        last_successful_update,
-    )
-    hass.bus.async_fire(
-        EVENT_ALERT_STALE_DATA,
-        {"last_successful": last_successful_update},
-    )
+    """Fire wx_watcher_alert_fetch_result event with fetch status."""
+    event_data: dict[str, Any] = {
+        "status": status,
+        "last_successful": last_successful,
+    }
+    if http_status is not None:
+        event_data["http_status"] = http_status
+    hass.bus.async_fire(EVENT_ALERT_FETCH_RESULT, event_data)

--- a/custom_components/wx_watcher/manifest.json
+++ b/custom_components/wx_watcher/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/nalabelle/wx_watcher/issues",
   "requirements": [],
-  "version": "8.1.1"
+  "version": "8.2.0"
 }

--- a/custom_components/wx_watcher/sensor.py
+++ b/custom_components/wx_watcher/sensor.py
@@ -9,26 +9,20 @@
 # be updated or removed accordingly.
 
 import logging
-from typing import Final
+from typing import Any, Final
 
-from homeassistant.components.sensor import SensorDeviceClass, SensorEntityDescription
+from homeassistant.components.sensor import SensorEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ATTRIBUTION
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import ATTRIBUTION, CONF_LOCATIONS, COORDINATOR, DEFAULT_NAME, DOMAIN
+from .const import ATTRIBUTION, COORDINATOR, DEFAULT_NAME, DOMAIN
 from .coordinator import AlertsDataUpdateCoordinator
 
 SENSOR_TYPES: Final[dict[str, SensorEntityDescription]] = {
     "state": SensorEntityDescription(key="state", name="Alerts", icon="mdi:alert"),
-    "last_updated": SensorEntityDescription(
-        name="Last Updated",
-        key="last_updated",
-        icon="mdi:update",
-        device_class=SensorDeviceClass.TIMESTAMP,
-    ),
 }
 
 _LOGGER = logging.getLogger(__name__)
@@ -74,30 +68,13 @@ class WXWatcherSensor(CoordinatorEntity):
     @property
     def extra_state_attributes(self):
         """Return the state attributes."""
-        attrs = {}
+        attrs: dict[str, Any] = {}
         if self.coordinator.data is None:
             return attrs
         if "alerts" in self.coordinator.data and self._key == "state":
             attrs["Alerts"] = self.coordinator.data["alerts"]
             if self.coordinator.nws_updated:
                 attrs["nws_updated"] = self.coordinator.nws_updated
-
-        locations = self._config.data.get(CONF_LOCATIONS, [])
-        if locations:
-            attrs["locations"] = []
-            for loc in locations:
-                entity_id = loc.get("ha_zone") or loc.get("tracker", "")
-                state = self._hass.states.get(entity_id)
-                attrs["locations"].append(
-                    {
-                        "entity": entity_id,
-                        "name": state.name if state else entity_id,
-                        "type": loc.get("type", ""),
-                        "mode": loc.get("mode", ""),
-                        "zone": loc.get("zone", ""),
-                        "gps": loc.get("gps", ""),
-                    }
-                )
 
         attrs[ATTR_ATTRIBUTION] = ATTRIBUTION
         return attrs

--- a/tests/test_coordinator_events.py
+++ b/tests/test_coordinator_events.py
@@ -10,7 +10,7 @@ from custom_components.wx_watcher.const import (
     DOMAIN,
     EVENT_ALERT_CLEARED,
     EVENT_ALERT_CREATED,
-    EVENT_ALERT_STALE_DATA,
+    EVENT_ALERT_FETCH_RESULT,
     EVENT_ALERT_UPDATED,
 )
 from tests.conftest import ZONE_URL
@@ -242,8 +242,8 @@ class TestAlertCleared:
 class TestApiFailure:
     """Tests for API failure handling."""
 
-    async def test_api_failure_fires_stale_data(self, hass, mock_aioclient):
-        """API failure should fire stale_data event, not alert events."""
+    async def test_api_failure_fires_fetch_result(self, hass, mock_aioclient):
+        """API failure should fire fetch_result event with http_error status."""
         for _ in range(2):
             mock_aioclient.get(ZONE_URL, status=200, body=load_fixture("api.json"))
         mock_aioclient.get(ZONE_URL, status=503)
@@ -256,7 +256,7 @@ class TestApiFailure:
         hass.bus.async_listen(EVENT_ALERT_CREATED, listener)
         hass.bus.async_listen(EVENT_ALERT_UPDATED, listener)
         hass.bus.async_listen(EVENT_ALERT_CLEARED, listener)
-        hass.bus.async_listen(EVENT_ALERT_STALE_DATA, listener)
+        hass.bus.async_listen(EVENT_ALERT_FETCH_RESULT, listener)
 
         entry = await _setup_entry(hass, mock_aioclient, CONFIG_DATA)
         assert len([e for e in events if e.event_type == EVENT_ALERT_CREATED]) == 2
@@ -267,16 +267,18 @@ class TestApiFailure:
         await coordinator.async_refresh()
         await hass.async_block_till_done()
 
-        stale_events = [e for e in events if e.event_type == EVENT_ALERT_STALE_DATA]
+        fetch_events = [e for e in events if e.event_type == EVENT_ALERT_FETCH_RESULT]
         alert_events = [
             e
             for e in events
             if e.event_type in (EVENT_ALERT_CREATED, EVENT_ALERT_UPDATED, EVENT_ALERT_CLEARED)
         ]
 
-        assert len(stale_events) == 1
+        assert len(fetch_events) == 1
         assert len(alert_events) == 0
-        assert stale_events[0].data["last_successful"] is not None
+        assert fetch_events[0].data["status"] == "http_error"
+        assert fetch_events[0].data["http_status"] == 503
+        assert fetch_events[0].data["last_successful"] is not None
 
 
 class TestPointMode:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -26,7 +26,7 @@ async def test_setup_entry(hass, mock_api, caplog):
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-        assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 2
+        assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 1
         entries = hass.config_entries.async_entries(DOMAIN)
         assert len(entries) == 1
 
@@ -44,7 +44,7 @@ async def test_unload_entry(hass, mock_api):
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 2
+    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 1
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -32,16 +32,6 @@ async def test_sensor(hass, mock_api):
     assert state
     assert state.state == "2"
     assert "Alerts" in state.attributes
-    assert "locations" in state.attributes
-
-    loc_info = state.attributes["locations"]
-    assert len(loc_info) == 1
-    assert loc_info[0]["entity"] == "zone.home"
-    assert loc_info[0]["name"] == "Home"
-    assert loc_info[0]["type"] == "static"
-    assert loc_info[0]["mode"] == "zone"
-    assert loc_info[0]["zone"] == "AZZ540,AZC013"
-    assert loc_info[0]["gps"] == "33.25,-112.30"
 
     entity_registry = er.async_get(hass)
     assert entity_registry.async_get(alerts_entity_id)


### PR DESCRIPTION
## Summary

- Remove `sensor.wx_watcher_last_updated` and `locations` attribute to stop writing to the recorder every 60-second poll cycle
- Enable `always_update=False` on `DataUpdateCoordinator` so the main Alerts sensor only records when alert data actually changes
- Replace `wx_watcher_alert_stale_data` with `wx_watcher_alert_fetch_result`, firing on every fetch (success and failure) with structured status (`ok`, `http_error`, `timeout`, `error`)

## Breaking changes

- **`sensor.wx_watcher_last_updated` removed.** Use entity availability for alive detection, `nws_updated` attribute for data freshness, or the `wx_watcher_alert_fetch_result` event for per-cycle status.
- **`wx_watcher_alert_stale_data` replaced by `wx_watcher_alert_fetch_result`** with different event type and data shape (includes `status`, `http_status`, `last_successful`).
- **`locations` attribute removed** from `sensor.wx_watcher_alerts`. Location config is visible in the integration's config entry options.

## Migration

```yaml
# Old (v8.1):
trigger:
  - platform: event
    event_type: wx_watcher_alert_stale_data

# New (v8.2):
trigger:
  - platform: event
    event_type: wx_watcher_alert_fetch_result
    event_data:
      status: timeout  # or http_error, error
```

## Test plan

- [x] All 67 existing tests pass
- [x] `test_api_failure_fires_fetch_result` updated to assert new event type, status (`http_error`), http_status (`503`), and `last_successful`
- [x] mypy, ruff, prettier all pass via pre-commit hooks
- [ ] Manual: verify `sensor.wx_watcher_alerts` no longer writes to recorder on unchanged polls
- [ ] Manual: verify `wx_watcher_alert_fetch_result` fires on success and failure
- [ ] Manual: verify entity goes unavailable on repeated failures

Assisted-by: GLM 5.1 via OpenCode