### PR TITLE
fix: add required title field to ticker clear notification

### DIFF
--- a/blueprints/automation/wx_watcher_ticker.yaml
+++ b/blueprints/automation/wx_watcher_ticker.yaml
@@ -112,6 +112,7 @@ actions:
     then:
       - action: ticker.notify
         data:
+          title: ""
           message: clear_notification
           data:
             tag: wx_{{ trigger.event.data.ID }}


### PR DESCRIPTION
## Summary

- The `ticker.notify` service requires a `title` field, but the clear notification action in the Ticker blueprint was missing it, causing `required key not provided @ data['title']` errors when alerts were cleared.
- Adds `title: ""` to the `ticker.notify` clear notification action. An empty string satisfies Ticker's voluputous schema validation (`vol.Required(ATTR_TITLE): cv.string`) while semantically indicating no visible title is needed for a clear/dismiss action. The `message: clear_notification` + `data.tag` pattern (HA Companion App convention) remains unchanged.

Assisted-by: GLM 5.1 via OpenCode