### PR TITLE
fix: defer first coordinator refresh until HA startup

### DIFF
--- a/custom_components/wx_watcher/__init__.py
+++ b/custom_components/wx_watcher/__init__.py
@@ -10,7 +10,8 @@
 import logging
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
+from homeassistant.core import CoreState, Event, HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.instance_id import async_get as async_get_instance_id
 
@@ -47,7 +48,13 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
 
-    await coordinator.async_refresh()
+    async def _async_first_refresh(_event: Event) -> None:
+        await coordinator.async_refresh()
+
+    if hass.state == CoreState.running:
+        await coordinator.async_refresh()
+    else:
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, _async_first_refresh)
 
     return True
 

--- a/custom_components/wx_watcher/const.py
+++ b/custom_components/wx_watcher/const.py
@@ -46,7 +46,7 @@ TIMEOUT_STEP = 5
 EVENT_ATTR_CONFIG_ENTRY_ID = "config_entry_id"
 EVENT_ATTR_SOURCES = "sources"
 
-VERSION = "8.2.0"
+VERSION = "8.3.0"
 ISSUE_URL = "https://github.com/nalabelle/wx_watcher"
 DOMAIN = "wx_watcher"
 PLATFORM = "sensor"

--- a/custom_components/wx_watcher/manifest.json
+++ b/custom_components/wx_watcher/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/nalabelle/wx_watcher/issues",
   "requirements": [],
-  "version": "8.2.2"
+  "version": "8.3.0"
 }

--- a/tests/test_coordinator_events.py
+++ b/tests/test_coordinator_events.py
@@ -13,6 +13,7 @@ from custom_components.wx_watcher.const import (
     EVENT_ALERT_FETCH_RESULT,
     EVENT_ALERT_UPDATED,
 )
+from homeassistant.core import CoreState
 from tests.conftest import ZONE_URL
 from tests.const import CONFIG_DATA, CONFIG_DATA_POINT_ONLY, CONFIG_DATA_TRACKER_IN_STATIC_ZONE
 
@@ -61,6 +62,7 @@ async def _setup_entry(hass, mock_aioclient, config_data, entry_title="WX Watche
         version=4,
     )
     entry.add_to_hass(hass)
+    hass.set_state(CoreState.running)
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
     return entry

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -7,13 +7,16 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.wx_watcher.const import DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.core import CoreState
 from tests.const import CONFIG_DATA
 
 pytestmark = pytest.mark.asyncio
 
 
-async def test_setup_entry(hass, mock_api, caplog):
-    """Test setting up entities."""
+async def test_setup_entry_cold_start(hass, mock_api, caplog):
+    """Test setup during cold start registers started listener instead of immediate refresh."""
+    hass.set_state(CoreState.not_running)
+
     with caplog.at_level(logging.DEBUG):
         entry = MockConfigEntry(
             domain=DOMAIN,
@@ -30,9 +33,41 @@ async def test_setup_entry(hass, mock_api, caplog):
         entries = hass.config_entries.async_entries(DOMAIN)
         assert len(entries) == 1
 
+        hass.bus.async_fire("homeassistant_started")
+        await hass.async_block_till_done()
+
+        coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+        assert coordinator.data is not None
+
+
+async def test_setup_entry_already_running(hass, mock_api, caplog):
+    """Test setup when HA is already running — refresh fires immediately."""
+    hass.set_state(CoreState.running)
+
+    with caplog.at_level(logging.DEBUG):
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="WX Watcher",
+            data=CONFIG_DATA,
+            version=4,
+        )
+
+        entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 1
+        entries = hass.config_entries.async_entries(DOMAIN)
+        assert len(entries) == 1
+
+        coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+        assert coordinator.data is not None
+
 
 async def test_unload_entry(hass, mock_api):
     """Test unloading entities."""
+    hass.set_state(CoreState.running)
+
     entry = MockConfigEntry(
         domain=DOMAIN,
         title="WX Watcher",

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -5,6 +5,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.wx_watcher.const import DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.core import CoreState
 from homeassistant.helpers import entity_registry as er
 from tests.const import CONFIG_DATA
 
@@ -13,6 +14,8 @@ pytestmark = pytest.mark.asyncio
 
 async def test_sensor(hass, mock_api):
     """Test sensors."""
+    hass.set_state(CoreState.running)
+
     entry = MockConfigEntry(
         domain=DOMAIN,
         title="WX Watcher",


### PR DESCRIPTION
## Summary

- Defer the initial coordinator refresh until `EVENT_HOMEASSISTANT_STARTED` fires, avoiding a race condition where `_get_tracker_gps()` runs before `device_tracker` entities are loaded during HA startup
- If HA is already running (reload/reconfigure), the refresh fires immediately as before via `CoreState.running` check
- Bumps version to 8.3.0

## Problem

During HA startup, the coordinator's first `async_refresh()` could execute before other platforms (e.g., `device_tracker`) had finished loading. This caused warnings:

```
Tracker entity device_tracker.nik_phone not found
Tracker device_tracker.nik_phone missing latitude/longitude attributes
```

## Changes

- **`__init__.py`**: Replaced direct `await coordinator.async_refresh()` with a listener that waits for `EVENT_HOMEASSISTANT_STARTED`. Falls back to immediate refresh when `hass.state == CoreState.running` (reload case).
- **Tests**: Added `test_setup_entry_cold_start` and `test_setup_entry_already_running` to cover both paths. Updated existing tests to set `CoreState.running` where immediate data is expected.
- **Version**: Bumped `manifest.json` and `const.py` to 8.3.0.

## Checklist

- [x] Tests pass (71/71)
- [x] Ruff lint clean
- [x] Pre-commit hooks pass

Assisted-by: Claude 4 Sonnet via OpenCode