### PR TITLE
fix: add startup grace period for tracker entity warnings

### DIFF
--- a/custom_components/wx_watcher/const.py
+++ b/custom_components/wx_watcher/const.py
@@ -8,6 +8,8 @@
 # As upstream-derived code is rewritten or removed, this comment should
 # be updated or removed accordingly.
 
+from datetime import timedelta
+
 from homeassistant.const import Platform
 
 API_ENDPOINT = "https://api.weather.gov"
@@ -46,7 +48,7 @@ TIMEOUT_STEP = 5
 EVENT_ATTR_CONFIG_ENTRY_ID = "config_entry_id"
 EVENT_ATTR_SOURCES = "sources"
 
-VERSION = "8.3.0"
+VERSION = "8.3.1"
 ISSUE_URL = "https://github.com/nalabelle/wx_watcher"
 DOMAIN = "wx_watcher"
 PLATFORM = "sensor"
@@ -54,6 +56,8 @@ ATTRIBUTION = "Data provided by Weather.gov"
 COORDINATOR = "coordinator"
 PLATFORMS = [Platform.SENSOR, Platform.NUMBER]
 CONFIG_VERSION = 5
+
+TRACKER_STARTUP_GRACE_PERIOD = timedelta(minutes=5)
 
 EVENT_ALERT_CREATED = f"{DOMAIN}_alert_created"
 EVENT_ALERT_UPDATED = f"{DOMAIN}_alert_updated"

--- a/custom_components/wx_watcher/coordinator.py
+++ b/custom_components/wx_watcher/coordinator.py
@@ -44,6 +44,7 @@ from .const import (
     LOCATION_TYPE_TRACKED,
     MAX_TIMEOUT,
     MIN_TIMEOUT,
+    TRACKER_STARTUP_GRACE_PERIOD,
 )
 from .events import async_fire_alert_events, async_fire_fetch_result_event
 
@@ -122,6 +123,8 @@ class AlertsDataUpdateCoordinator(DataUpdateCoordinator):
         self._last_successful_update: str | None = None
         self._nws_updated: str | None = None
         self._tracker_gps_warned: dict[str, datetime] = {}
+        self._startup_time: datetime = datetime.now(tz=UTC)
+        self._trackers_seen: set[str] = set()
 
         _LOGGER.debug("Data will be updated every %s", self._interval)
 
@@ -376,10 +379,26 @@ class AlertsDataUpdateCoordinator(DataUpdateCoordinator):
         """Return ``lat,lon`` string for a tracker entity, or None."""
         entity = self.hass.states.get(tracker_entity_id)
         if entity is None:
-            _LOGGER.warning("Tracker entity %s not found", tracker_entity_id)
+            now = datetime.now(tz=UTC)
+            if tracker_entity_id in self._trackers_seen:
+                _LOGGER.warning(
+                    "Tracker entity %s previously available but now missing",
+                    tracker_entity_id,
+                )
+            elif (now - self._startup_time) > TRACKER_STARTUP_GRACE_PERIOD:
+                _LOGGER.warning(
+                    "Tracker entity %s not found after startup grace period",
+                    tracker_entity_id,
+                )
+            else:
+                _LOGGER.debug(
+                    "Tracker entity %s not found (startup grace period)",
+                    tracker_entity_id,
+                )
             return None
         attrs = entity.attributes
         if "latitude" in attrs and "longitude" in attrs:
+            self._trackers_seen.add(tracker_entity_id)
             self._tracker_gps_warned.pop(tracker_entity_id, None)
             return f"{attrs['latitude']},{attrs['longitude']}"
         now = datetime.now(tz=UTC)

--- a/custom_components/wx_watcher/manifest.json
+++ b/custom_components/wx_watcher/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/nalabelle/wx_watcher/issues",
   "requirements": [],
-  "version": "8.3.0"
+  "version": "8.3.1"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -554,6 +554,9 @@ ignore = [
   "PLE0605",
 ]
 
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*" = ["SLF001"]
+
 [tool.ruff.lint.flake8-import-conventions.extend-aliases]
 voluptuous = "vol"
 "homeassistant.components.air_quality.PLATFORM_SCHEMA" = "AIR_QUALITY_PLATFORM_SCHEMA"

--- a/tests/const.py
+++ b/tests/const.py
@@ -86,3 +86,18 @@ CONFIG_DATA_TRACKER_IN_STATIC_ZONE = {
         },
     ],
 }
+
+CONFIG_DATA_TRACKER_ONLY = {
+    "name": "WX Watcher",
+    "interval": 60,
+    "timeout": 60,
+    "locations": [
+        {
+            CONF_LOCATION_TYPE: LOCATION_TYPE_TRACKED,
+            CONF_LOCATION_MODE: LOCATION_MODE_POINT,
+            CONF_LOCATION_GPS: "",
+            CONF_LOCATION_ZONE: "",
+            CONF_LOCATION_TRACKER: "device_tracker.phone",
+        },
+    ],
+}

--- a/tests/test_tracker_gps.py
+++ b/tests/test_tracker_gps.py
@@ -1,0 +1,125 @@
+"""Tests for tracker GPS startup grace period and missing-tracker warnings."""
+
+from datetime import UTC, datetime, timedelta
+import logging
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.wx_watcher.const import DOMAIN, TRACKER_STARTUP_GRACE_PERIOD
+from homeassistant.core import CoreState
+from tests.conftest import load_fixture
+from tests.const import CONFIG_DATA_TRACKER_ONLY
+
+pytestmark = pytest.mark.asyncio
+
+TRACKER_ENTITY = "device_tracker.phone"
+TRACKER_POINT_URL = "https://api.weather.gov/alerts/active?point=33.5,-112.0"
+
+
+async def _setup_entry(hass, mock_aioclient, config_data):
+    """Set up a mock config entry and return (entry, coordinator)."""
+    hass.set_state(CoreState.running)
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="WX Watcher",
+        data=config_data,
+        version=4,
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+    return entry, coordinator
+
+
+async def test_tracker_not_found_within_grace_period_logs_debug(hass, mock_aioclient, caplog):
+    """Tracker not found within grace period should log debug, not warning."""
+    mock_aioclient.get(TRACKER_POINT_URL, status=200, body=load_fixture("api.json"))
+
+    with caplog.at_level(logging.DEBUG):
+        _, coordinator = await _setup_entry(hass, mock_aioclient, CONFIG_DATA_TRACKER_ONLY)
+
+        coordinator._startup_time = datetime.now(tz=UTC)
+        await coordinator._get_tracker_gps(TRACKER_ENTITY)
+
+        assert any(
+            "startup grace period" in r.message and r.levelno == logging.DEBUG
+            for r in caplog.records
+        )
+        assert not any(
+            "not found" in r.message and r.levelno == logging.WARNING for r in caplog.records
+        )
+
+
+async def test_tracker_not_found_after_grace_period_logs_warning(hass, mock_aioclient, caplog):
+    """Tracker not found after grace period should log warning."""
+    mock_aioclient.get(TRACKER_POINT_URL, status=200, body=load_fixture("api.json"))
+
+    with caplog.at_level(logging.DEBUG):
+        _, coordinator = await _setup_entry(hass, mock_aioclient, CONFIG_DATA_TRACKER_ONLY)
+
+        coordinator._startup_time = (
+            datetime.now(tz=UTC) - TRACKER_STARTUP_GRACE_PERIOD - timedelta(seconds=1)
+        )
+        await coordinator._get_tracker_gps(TRACKER_ENTITY)
+
+        assert any(
+            "not found after startup grace period" in r.message and r.levelno == logging.WARNING
+            for r in caplog.records
+        )
+
+
+async def test_tracker_previously_seen_now_missing_logs_warning(hass, mock_aioclient, caplog):
+    """Tracker that was previously available but now missing should always warn."""
+    mock_aioclient.get(TRACKER_POINT_URL, status=200, body=load_fixture("api.json"))
+
+    with caplog.at_level(logging.DEBUG):
+        _, coordinator = await _setup_entry(hass, mock_aioclient, CONFIG_DATA_TRACKER_ONLY)
+
+        coordinator._startup_time = datetime.now(tz=UTC)
+        coordinator._trackers_seen.add(TRACKER_ENTITY)
+        await coordinator._get_tracker_gps(TRACKER_ENTITY)
+
+        assert any(
+            "previously available but now missing" in r.message and r.levelno == logging.WARNING
+            for r in caplog.records
+        )
+
+
+async def test_tracker_found_added_to_seen(hass, mock_aioclient):
+    """Successful GPS lookup should add tracker to _trackers_seen."""
+    mock_aioclient.get(TRACKER_POINT_URL, status=200, body=load_fixture("api.json"))
+
+    _, coordinator = await _setup_entry(hass, mock_aioclient, CONFIG_DATA_TRACKER_ONLY)
+
+    hass.states.async_set(
+        TRACKER_ENTITY,
+        "not_home",
+        {"latitude": 33.50, "longitude": -112.00, "friendly_name": "Phone"},
+    )
+
+    result = await coordinator._get_tracker_gps(TRACKER_ENTITY)
+    assert result == "33.5,-112.0"
+    assert TRACKER_ENTITY in coordinator._trackers_seen
+
+
+async def test_tracker_previously_seen_warns_every_time(hass, mock_aioclient, caplog):
+    """Previously-seen tracker gone missing should warn on every call."""
+    mock_aioclient.get(TRACKER_POINT_URL, status=200, body=load_fixture("api.json"))
+
+    with caplog.at_level(logging.DEBUG):
+        _, coordinator = await _setup_entry(hass, mock_aioclient, CONFIG_DATA_TRACKER_ONLY)
+
+        coordinator._startup_time = datetime.now(tz=UTC)
+        coordinator._trackers_seen.add(TRACKER_ENTITY)
+
+        await coordinator._get_tracker_gps(TRACKER_ENTITY)
+        await coordinator._get_tracker_gps(TRACKER_ENTITY)
+
+        warnings = [
+            r
+            for r in caplog.records
+            if "previously available but now missing" in r.message and r.levelno == logging.WARNING
+        ]
+        assert len(warnings) == 2


### PR DESCRIPTION
## Summary

- Adds a 5-minute startup grace period for missing tracker entities — logs `debug` instead of `warning` during this window
- After the grace period, missing trackers that were never seen log `warning` every refresh
- Trackers that were previously working but disappear always log `warning` immediately (safety concern)
- Successfully resolved trackers are tracked in `_trackers_seen` to distinguish startup noise from real failures

## Problem

After the v8.3.0 deferred startup fix, tracker entities that register *after* `EVENT_HOMEASSISTANT_STARTED` (e.g., mobile app device trackers) still produced a `warning` on the first refresh. This is expected and not actionable during the first few minutes of HA startup.

## Changes

- **`coordinator.py`**: `_get_tracker_gps()` now uses `_startup_time` and `_trackers_seen` to choose appropriate log levels
- **`const.py`**: Added `TRACKER_STARTUP_GRACE_PERIOD = timedelta(minutes=5)`
- **`tests/test_tracker_gps.py`**: New test file covering all branches (grace period, post-grace, previously-seen, found)
- **`pyproject.toml`**: Added ruff per-file-ignores for SLF001 in tests
- Version bumped to 8.3.1

## Checklist

- [x] Tests pass (76/76)
- [x] Ruff lint clean
- [x] Pre-commit hooks pass

Assisted-by: GLM 5.1 via OpenCode