### PR TITLE
feat(ci): add git-cliff auto-release with HACS/hassfest validation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024-2026 nalabelle
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/custom_components/wx_watcher/manifest.json
+++ b/custom_components/wx_watcher/manifest.json
@@ -5,8 +5,10 @@
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/nalabelle/wx_watcher/",
+  "integration_type": "service",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/nalabelle/wx_watcher/issues",
+  "loggers": ["custom_components.wx_watcher"],
   "requirements": [],
   "version": "8.4.1"
 }


### PR DESCRIPTION
## Changes

- **Add `validate` job** to release workflow — runs Hassfest + HACS validation before tagging (GitHub only)
- **Replace hand-rolled release notes** with `orhun/git-cliff-action@v4` — generates categorized release notes from conventional commits
- **Add `cliff.toml`** — git-cliff config grouping commits by type (Features, Bug Fixes, Performance, Documentation, Refactoring, Miscellaneous)
- **Add MIT LICENSE** — required by HACS
- **Add `integration_type: service`** and **`loggers`** to manifest.json — required/recommended by hassfest
- **Fix `VERSION` mismatch** in const.py (8.4.0 → 8.4.1)

## Release flow (GitHub only)

1. Push to `main`
2. `validate` — Hassfest + HACS checks
3. `tag` — reads version from `manifest.json`, creates `v{version}` tag
4. `release` — git-cliff generates categorized notes, creates GitHub Release

Assisted-by: GLM 5.1 via OpenCode